### PR TITLE
fix: clean up orphaned resources and subscriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,6 @@ This project uses pnpm with corepack. Run `corepack enable` to set up pnpm autom
 ### Testing & Quality
 
 - `pnpm test` - Run full API tests using Docker containers (MacOS tested)
-- `pnpm run test-internal` - Run Mocha test suite directly
 - `pnpm run lint` - Run ESLint with auto-fix on controllers/, services/, test/
 
 ### Data Management

--- a/services/json-store.js
+++ b/services/json-store.js
@@ -29,6 +29,7 @@ function setResource(feedUrl, resourceObj) {
     }
     const clean = Object.assign({}, resourceObj);
     delete clean._id;
+    delete clean.flDirty;
     data[feedUrl].resource = clean;
 }
 
@@ -41,6 +42,10 @@ function setSubscriptions(feedUrl, pleaseNotifyArray) {
         delete clean._id;
         return clean;
     });
+}
+
+function removeEntry(feedUrl) {
+    delete data[feedUrl];
 }
 
 function getData() {
@@ -77,6 +82,7 @@ module.exports = {
     initialize,
     setResource,
     setSubscriptions,
+    removeEntry,
     getData,
     clear,
     flush,

--- a/services/please-notify.js
+++ b/services/please-notify.js
@@ -7,28 +7,8 @@ const appMessages = require('./app-messages'),
     logEvent = require('./log-event'),
     mongodb = require('./mongodb'),
     notifyOne = require('./notify-one'),
-    notifyOneChallenge = require('./notify-one-challenge');
-
-async function checkresourceUrlStatusCode(resourceUrl) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), config.requestTimeout);
-
-    try {
-        const res = await fetch(resourceUrl, {
-            method: 'GET',
-            signal: controller.signal
-        });
-
-        clearTimeout(timeoutId);
-
-        if (res.status < 200 || res.status > 299) {
-            throw new ErrorResponse(appMessages.error.subscription.readResource(resourceUrl));
-        }
-    } catch {
-        clearTimeout(timeoutId);
-        throw new ErrorResponse(appMessages.error.subscription.readResource(resourceUrl));
-    }
-}
+    notifyOneChallenge = require('./notify-one-challenge'),
+    ping = require('./ping');
 
 async function fetchSubscriptions(resourceUrl) {
     const subscriptions = await mongodb.get('rsscloud')
@@ -98,7 +78,11 @@ async function pleaseNotify(notifyProcedure, apiurl, protocol, urlList, diffDoma
 
     const results = await Promise.allSettled(
         urlList.map(async(resourceUrl) => {
-            await checkresourceUrlStatusCode(resourceUrl);
+            try {
+                await ping(resourceUrl);
+            } catch {
+                throw new ErrorResponse(appMessages.error.subscription.readResource(resourceUrl));
+            }
             await notifyApiUrl(notifyProcedure, apiurl, protocol, resourceUrl, diffDomain);
         })
     );

--- a/services/remove-expired-subscriptions.js
+++ b/services/remove-expired-subscriptions.js
@@ -2,6 +2,7 @@ const mongodb = require('./mongodb');
 const getDayjs = require('./dayjs-wrapper');
 const jsonStore = require('./json-store');
 const config = require('../config');
+const ping = require('./ping');
 
 /**
  * Removes expired and errored subscriptions from MongoDB
@@ -50,7 +51,15 @@ async function removeExpiredSubscriptions() {
                 if (validSubscriptions.length === 0) {
                     // Remove entire document if no valid subscriptions remain
                     await collection.deleteOne({ _id: doc._id });
-                    jsonStore.setSubscriptions(doc._id, []);
+
+                    // Only remove resource if it wasn't checked in the last 24 hours
+                    const resource = await db.collection('resources').findOne({ _id: doc._id });
+                    if (resource && dayjs(resource.whenLastCheck).isAfter(dayjs().subtract(24, 'hours'))) {
+                        jsonStore.setSubscriptions(doc._id, []);
+                    } else {
+                        await db.collection('resources').deleteOne({ _id: doc._id });
+                        jsonStore.removeEntry(doc._id);
+                    }
                     documentsDeleted++;
                 } else {
                     // Update document with filtered subscriptions
@@ -63,12 +72,45 @@ async function removeExpiredSubscriptions() {
             }
         }
 
+        // Find subscriptions with no corresponding resource and create resources
+        let resourcesCreated = 0;
+        const orphanedCursor = collection.aggregate([
+            {
+                $lookup: {
+                    from: 'resources',
+                    localField: '_id',
+                    foreignField: '_id',
+                    as: 'resource'
+                }
+            },
+            {
+                $match: {
+                    resource: { $size: 0 }
+                }
+            }
+        ]);
+
+        while (await orphanedCursor.hasNext()) {
+            const doc = await orphanedCursor.next();
+            try {
+                await ping(doc._id);
+                resourcesCreated++;
+            } catch (err) {
+                console.log(`Failed to create resource for ${doc._id}: ${err.message}`);
+            }
+        }
+
+        if (resourcesCreated > 0) {
+            console.log(`Created ${resourcesCreated} missing resource documents`);
+        }
+
         console.log(`Subscription cleanup completed: ${totalRemoved} expired/errored subscriptions removed, ${documentsProcessed} documents processed, ${documentsDeleted} empty documents deleted`);
 
         return {
             subscriptionsRemoved: totalRemoved,
             documentsProcessed,
-            documentsDeleted
+            documentsDeleted,
+            resourcesCreated
         };
 
     } catch (error) {

--- a/test/mongodb.js
+++ b/test/mongodb.js
@@ -24,6 +24,25 @@ async function upsertSubscriptions(subscriptions) {
 }
 
 module.exports = {
+    addResource: async function(resourceUrl, resourceObj) {
+        await mongodb.get('rsscloud')
+            .collection('resources')
+            .replaceOne(
+                { _id: resourceUrl },
+                Object.assign({ _id: resourceUrl }, resourceObj),
+                { upsert: true }
+            );
+    },
+    findResource: async function(resourceUrl) {
+        return mongodb.get('rsscloud')
+            .collection('resources')
+            .findOne({ _id: resourceUrl });
+    },
+    findSubscription: async function(resourceUrl) {
+        return mongodb.get('rsscloud')
+            .collection('subscriptions')
+            .findOne({ _id: resourceUrl });
+    },
     addSubscription: async function(resourceUrl, notifyProcedure, apiurl, protocol) {
         const subscriptions = await fetchSubscriptions(resourceUrl);
 

--- a/test/please-notify.js
+++ b/test/please-notify.js
@@ -127,6 +127,12 @@ for (const protocol of ['http-post', 'https-post', 'xml-rpc']) {
                     } else {
                         expect(mock.requests.GET).property(pingPath).lengthOf(1, `Missing GET ${pingPath}`);
                     }
+
+                    // Verify resource document was created
+                    const resDoc = await mongodb.findResource(resourceUrl);
+                    expect(resDoc).to.not.be.null;
+                    expect(resDoc).to.have.property('lastHash');
+                    expect(resDoc).to.have.property('lastSize');
                 });
 
                 it('should accept a pleaseNotify without domain for new resource', async function() {

--- a/test/remove-expired-subscriptions.js
+++ b/test/remove-expired-subscriptions.js
@@ -1,0 +1,185 @@
+const chai = require('chai'),
+    config = require('../config'),
+    expect = chai.expect,
+    getDayjs = require('../services/dayjs-wrapper'),
+    jsonStore = require('../services/json-store'),
+    mock = require('./mock'),
+    mongodb = require('./mongodb'),
+    removeExpiredSubscriptions = require('../services/remove-expired-subscriptions');
+
+describe('RemoveExpiredSubscriptions', function() {
+
+    before(async function() {
+        await mongodb.before();
+        await mock.before();
+    });
+
+    after(async function() {
+        await mongodb.after();
+        await mock.after();
+    });
+
+    beforeEach(async function() {
+        await mongodb.beforeEach();
+        await mock.beforeEach();
+    });
+
+    afterEach(async function() {
+        await mongodb.afterEach();
+        await mock.afterEach();
+    });
+
+    it('should remove expired subscriptions', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            pingPath = '/feedupdated',
+            apiurl = mock.serverUrl + pingPath,
+            dayjs = await getDayjs();
+
+        const subscription = await mongodb.addSubscription(resourceUrl, false, apiurl, 'http-post');
+        subscription.whenExpires = dayjs().utc().subtract(config.ctSecsResourceExpire * 2, 'seconds').format();
+        await mongodb.updateSubscription(resourceUrl, subscription);
+
+        await removeExpiredSubscriptions();
+
+        const doc = await mongodb.findSubscription(resourceUrl);
+        expect(doc).to.be.null;
+    });
+
+    it('should remove resource when all subscriptions are removed', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            pingPath = '/feedupdated',
+            apiurl = mock.serverUrl + pingPath,
+            dayjs = await getDayjs();
+
+        // Add subscription and resource
+        const subscription = await mongodb.addSubscription(resourceUrl, false, apiurl, 'http-post');
+        subscription.whenExpires = dayjs().utc().subtract(config.ctSecsResourceExpire * 2, 'seconds').format();
+        await mongodb.updateSubscription(resourceUrl, subscription);
+
+        await mongodb.addResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            ctChecks: 1,
+            ctUpdates: 0,
+            whenLastCheck: new Date(dayjs().utc().subtract(48, 'hours').format())
+        });
+        jsonStore.setResource(resourceUrl, { lastHash: 'abc', lastSize: 100 });
+        jsonStore.setSubscriptions(resourceUrl, [subscription]);
+
+        await removeExpiredSubscriptions();
+
+        // Subscription document should be gone
+        const subDoc = await mongodb.findSubscription(resourceUrl);
+        expect(subDoc).to.be.null;
+
+        // Resource document should also be gone (last checked 48 hours ago)
+        const resDoc = await mongodb.findResource(resourceUrl);
+        expect(resDoc).to.be.null;
+
+        // JSON store entry should be fully removed
+        const storeData = jsonStore.getData();
+        expect(storeData).to.not.have.property(resourceUrl);
+    });
+
+    it('should keep resource when recently checked even if all subscriptions are removed', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            pingPath = '/feedupdated',
+            apiurl = mock.serverUrl + pingPath,
+            dayjs = await getDayjs();
+
+        // Add subscription and recently-checked resource
+        const subscription = await mongodb.addSubscription(resourceUrl, false, apiurl, 'http-post');
+        subscription.whenExpires = dayjs().utc().subtract(config.ctSecsResourceExpire * 2, 'seconds').format();
+        await mongodb.updateSubscription(resourceUrl, subscription);
+
+        await mongodb.addResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            ctChecks: 1,
+            ctUpdates: 0,
+            whenLastCheck: new Date(dayjs().utc().subtract(1, 'hour').format())
+        });
+        jsonStore.setResource(resourceUrl, { lastHash: 'abc', lastSize: 100 });
+        jsonStore.setSubscriptions(resourceUrl, [subscription]);
+
+        await removeExpiredSubscriptions();
+
+        // Subscription document should be gone
+        const subDoc = await mongodb.findSubscription(resourceUrl);
+        expect(subDoc).to.be.null;
+
+        // Resource document should still exist (checked 1 hour ago)
+        const resDoc = await mongodb.findResource(resourceUrl);
+        expect(resDoc).to.not.be.null;
+
+        // JSON store should still have the resource but with empty subscribers
+        const storeData = jsonStore.getData();
+        expect(storeData).to.have.property(resourceUrl);
+        expect(storeData[resourceUrl].subscribers).to.have.lengthOf(0);
+    });
+
+    it('should not remove resource when valid subscriptions remain', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            pingPath1 = '/feedupdated1',
+            pingPath2 = '/feedupdated2',
+            apiurl1 = mock.serverUrl + pingPath1,
+            apiurl2 = mock.serverUrl + pingPath2,
+            dayjs = await getDayjs();
+
+        // Add two subscriptions - one expired, one valid
+        const subscription1 = await mongodb.addSubscription(resourceUrl, false, apiurl1, 'http-post');
+        subscription1.whenExpires = dayjs().utc().subtract(config.ctSecsResourceExpire * 2, 'seconds').format();
+        await mongodb.updateSubscription(resourceUrl, subscription1);
+
+        await mongodb.addSubscription(resourceUrl, false, apiurl2, 'http-post');
+
+        // Add resource
+        await mongodb.addResource(resourceUrl, {
+            lastHash: 'abc', lastSize: 100, ctChecks: 1, ctUpdates: 0
+        });
+
+        await removeExpiredSubscriptions();
+
+        // Subscription document should still exist with valid subscription
+        const subDoc = await mongodb.findSubscription(resourceUrl);
+        expect(subDoc).to.not.be.null;
+        expect(subDoc.pleaseNotify).to.have.lengthOf(1);
+        expect(subDoc.pleaseNotify[0].url).to.equal(apiurl2);
+
+        // Resource document should still exist
+        const resDoc = await mongodb.findResource(resourceUrl);
+        expect(resDoc).to.not.be.null;
+    });
+
+    it('should create resource for subscription without one', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            pingPath = '/feedupdated',
+            apiurl = mock.serverUrl + pingPath;
+
+        // Add subscription but no resource document
+        await mongodb.addSubscription(resourceUrl, false, apiurl, 'http-post');
+
+        // Set up mock to serve feed
+        mock.route('GET', feedPath, 200, '<RSS Feed />');
+
+        await removeExpiredSubscriptions();
+
+        // Resource document should now exist
+        const resDoc = await mongodb.findResource(resourceUrl);
+        expect(resDoc).to.not.be.null;
+        expect(resDoc).to.have.property('lastHash');
+        expect(resDoc).to.have.property('lastSize');
+
+        // JSON store should also have the resource
+        const storeData = jsonStore.getData();
+        expect(storeData).to.have.property(resourceUrl);
+        expect(storeData[resourceUrl]).to.have.property('resource');
+        expect(storeData[resourceUrl].resource).to.have.property('lastHash');
+    });
+
+});


### PR DESCRIPTION
- Replace checkresourceUrlStatusCode with ping in pleaseNotify so resource documents are created at subscription time
- Remove orphaned resources when all subscriptions expire (unless the resource was checked within the last 24 hours)
- Create missing resource documents for subscriptions without one
- Add removeEntry to json-store for full entry cleanup
- Strip flDirty from resource objects in json-store