### PR TITLE
feat: retain empty-subscriber entries within feedsChangedWindowDays

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,5 +24,6 @@ module.exports = {
     requestTimeout: getNumericConfig('REQUEST_TIMEOUT', 4000),
     dataFilePath: getConfig('DATA_FILE_PATH', './data/subscriptions.json'),
     statsFilePath: getConfig('STATS_FILE_PATH', './data/stats.json'),
-    statsIntervalMs: getNumericConfig('STATS_INTERVAL_MS', 3600000)
+    statsIntervalMs: getNumericConfig('STATS_INTERVAL_MS', 3600000),
+    feedsChangedWindowDays: getNumericConfig('FEEDS_CHANGED_WINDOW_DAYS', 7)
 };

--- a/services/remove-expired-subscriptions.js
+++ b/services/remove-expired-subscriptions.js
@@ -3,6 +3,13 @@ const getDayjs = require('./dayjs-wrapper');
 const jsonStore = require('./json-store');
 const config = require('../config');
 
+function shouldRetainEmptyEntry(entry, cutoff, dayjs) {
+    if (!entry.resource || !entry.resource.whenLastUpdate) {
+        return false;
+    }
+    return dayjs(entry.resource.whenLastUpdate).isAfter(cutoff);
+}
+
 /**
  * Removes expired and errored subscriptions
  * Reads from jsonStore, writes to both MongoDB and jsonStore
@@ -12,6 +19,7 @@ async function removeExpiredSubscriptions() {
         const db = mongodb.get('rsscloud');
         const dayjs = await getDayjs();
         const collection = db.collection('subscriptions');
+        const cutoff = dayjs().utc().subtract(config.feedsChangedWindowDays, 'days');
 
         let totalRemoved = 0;
         let documentsProcessed = 0;
@@ -23,7 +31,9 @@ async function removeExpiredSubscriptions() {
             documentsProcessed++;
 
             if (!entry.subscribers || !Array.isArray(entry.subscribers) || entry.subscribers.length === 0) {
-                // Remove entries with missing or empty subscribers
+                if (shouldRetainEmptyEntry(entry, cutoff, dayjs)) {
+                    continue;
+                }
                 await collection.deleteOne({ _id: feedUrl });
                 await db.collection('resources').deleteOne({ _id: feedUrl });
                 jsonStore.removeEntry(feedUrl);
@@ -51,11 +61,18 @@ async function removeExpiredSubscriptions() {
             // Update if subscriptions were removed
             if (validSubscriptions.length !== entry.subscribers.length) {
                 if (validSubscriptions.length === 0) {
-                    // Remove entire entry if no valid subscriptions remain
-                    await collection.deleteOne({ _id: feedUrl });
-                    await db.collection('resources').deleteOne({ _id: feedUrl });
-                    jsonStore.removeEntry(feedUrl);
-                    documentsDeleted++;
+                    if (shouldRetainEmptyEntry(entry, cutoff, dayjs)) {
+                        await collection.updateOne(
+                            { _id: feedUrl },
+                            { $set: { pleaseNotify: [] } }
+                        );
+                        jsonStore.setSubscriptions(feedUrl, []);
+                    } else {
+                        await collection.deleteOne({ _id: feedUrl });
+                        await db.collection('resources').deleteOne({ _id: feedUrl });
+                        jsonStore.removeEntry(feedUrl);
+                        documentsDeleted++;
+                    }
                 } else {
                     // Update with filtered subscriptions
                     await collection.updateOne(
@@ -96,7 +113,6 @@ async function removeExpiredSubscriptions() {
             }
         }
 
-
         // Find resources with no corresponding subscription and remove them
         let orphanedResourcesRemoved = 0;
         const latestData = jsonStore.getData();
@@ -104,6 +120,9 @@ async function removeExpiredSubscriptions() {
         for (const [feedUrl, entry] of Object.entries(latestData)) {
             if (entry.resource && Object.keys(entry.resource).length > 0 &&
                 (!entry.subscribers || entry.subscribers.length === 0)) {
+                if (shouldRetainEmptyEntry(entry, cutoff, dayjs)) {
+                    continue;
+                }
                 await db.collection('resources').deleteOne({ _id: feedUrl });
                 jsonStore.removeEntry(feedUrl);
                 orphanedResourcesRemoved++;

--- a/services/stats.js
+++ b/services/stats.js
@@ -29,7 +29,7 @@ function getStats() {
 async function generateStats() {
     const dayjs = await getDayjs();
     const now = dayjs().utc().format();
-    const sevenDaysAgo = dayjs().utc().subtract(7, 'days').toDate();
+    const cutoff = dayjs().utc().subtract(config.feedsChangedWindowDays, 'days').toDate();
 
     const data = jsonStore.getData();
 
@@ -40,10 +40,9 @@ async function generateStats() {
     const feedCounts = [];
 
     for (const [feedUrl, entry] of Object.entries(data)) {
-        // Count feeds changed in last 7 days
         if (entry.resource?.whenLastUpdate) {
             const lastUpdate = new Date(entry.resource.whenLastUpdate);
-            if (lastUpdate >= sevenDaysAgo) {
+            if (lastUpdate >= cutoff) {
                 feedsChangedLast7Days++;
             }
         }

--- a/test/remove-expired-subscriptions.js
+++ b/test/remove-expired-subscriptions.js
@@ -83,14 +83,13 @@ describe('RemoveExpiredSubscriptions', function() {
         expect(storeData).to.not.have.property(resourceUrl);
     });
 
-    it('should remove recently-checked resource when all subscriptions are removed', async function() {
+    it('should remove resource when all subscriptions are removed and whenLastUpdate is absent', async function() {
         const feedPath = '/rss.xml',
             resourceUrl = mock.serverUrl + feedPath,
             pingPath = '/feedupdated',
             apiurl = mock.serverUrl + pingPath,
             dayjs = await getDayjs();
 
-        // Add subscription and recently-checked resource
         const subscription = await mongodb.addSubscription(resourceUrl, false, apiurl, 'http-post');
         subscription.whenExpires = dayjs().utc().subtract(config.ctSecsResourceExpire * 2, 'seconds').format();
         await mongodb.updateSubscription(resourceUrl, subscription);
@@ -118,6 +117,115 @@ describe('RemoveExpiredSubscriptions', function() {
         // JSON store entry should be fully removed
         const storeData = jsonStore.getData();
         expect(storeData).to.not.have.property(resourceUrl);
+    });
+
+    it('should retain empty-subscribers entry when whenLastUpdate is within retention window', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            dayjs = await getDayjs();
+
+        const recentUpdate = new Date(dayjs().utc().subtract(1, 'day').format());
+
+        await mongodb.addResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            ctChecks: 1,
+            ctUpdates: 1,
+            whenLastUpdate: recentUpdate
+        });
+        jsonStore.setResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            whenLastUpdate: recentUpdate
+        });
+        jsonStore.setSubscriptions(resourceUrl, []);
+
+        await removeExpiredSubscriptions();
+
+        // Resource should still exist in MongoDB
+        const resDoc = await mongodb.findResource(resourceUrl);
+        expect(resDoc).to.not.be.null;
+
+        // JSON store entry should still exist with empty subscribers
+        const storeData = jsonStore.getData();
+        expect(storeData).to.have.property(resourceUrl);
+        expect(storeData[resourceUrl].subscribers).to.deep.equal([]);
+    });
+
+    it('should remove empty-subscribers entry when whenLastUpdate is beyond retention window', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            dayjs = await getDayjs();
+
+        const staleUpdate = new Date(dayjs().utc().subtract(config.feedsChangedWindowDays + 1, 'days').format());
+
+        await mongodb.addResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            ctChecks: 1,
+            ctUpdates: 1,
+            whenLastUpdate: staleUpdate
+        });
+        jsonStore.setResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            whenLastUpdate: staleUpdate
+        });
+        jsonStore.setSubscriptions(resourceUrl, []);
+
+        await removeExpiredSubscriptions();
+
+        // Resource should be gone from MongoDB
+        const resDoc = await mongodb.findResource(resourceUrl);
+        expect(resDoc).to.be.null;
+
+        // JSON store entry should be fully removed
+        const storeData = jsonStore.getData();
+        expect(storeData).to.not.have.property(resourceUrl);
+    });
+
+    it('should retain entry when last subscription expires but whenLastUpdate is recent', async function() {
+        const feedPath = '/rss.xml',
+            resourceUrl = mock.serverUrl + feedPath,
+            pingPath = '/feedupdated',
+            apiurl = mock.serverUrl + pingPath,
+            dayjs = await getDayjs();
+
+        const recentUpdate = new Date(dayjs().utc().subtract(1, 'day').format());
+
+        const subscription = await mongodb.addSubscription(resourceUrl, false, apiurl, 'http-post');
+        subscription.whenExpires = dayjs().utc().subtract(config.ctSecsResourceExpire * 2, 'seconds').format();
+        await mongodb.updateSubscription(resourceUrl, subscription);
+
+        await mongodb.addResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            ctChecks: 1,
+            ctUpdates: 1,
+            whenLastUpdate: recentUpdate
+        });
+        jsonStore.setResource(resourceUrl, {
+            lastHash: 'abc',
+            lastSize: 100,
+            whenLastUpdate: recentUpdate
+        });
+        jsonStore.setSubscriptions(resourceUrl, [subscription]);
+
+        await removeExpiredSubscriptions();
+
+        // Subscription document should still exist with empty pleaseNotify
+        const subDoc = await mongodb.findSubscription(resourceUrl);
+        expect(subDoc).to.not.be.null;
+        expect(subDoc.pleaseNotify).to.deep.equal([]);
+
+        // Resource document should still exist
+        const resDoc = await mongodb.findResource(resourceUrl);
+        expect(resDoc).to.not.be.null;
+
+        // JSON store entry should still exist with empty subscribers
+        const storeData = jsonStore.getData();
+        expect(storeData).to.have.property(resourceUrl);
+        expect(storeData[resourceUrl].subscribers).to.deep.equal([]);
     });
 
     it('should not remove resource when valid subscriptions remain', async function() {


### PR DESCRIPTION
Cleanup previously deleted any subscriptions.json entry with an empty subscribers array, which dropped feeds that had been recently updated before stats.js could count them. Now entries are kept until resource.whenLastUpdate falls outside the configured window (FEEDS_CHANGED_WINDOW_DAYS, default 7), keeping the "Feeds changed in last 7 days" stat accurate even for unsubscribed feeds.