### PR TITLE
feat(client): rewrite as a unified, session-scoped rssCloud/WebSub test harness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,7 @@ packages/*/coverage
 .turbo
 **/xunit
 .nyc_output
-.env
+**/.env
 .DS_Store
 Procfile
 tunnel.sh

--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -1,0 +1,38 @@
+# rssCloud test harness — environment template.
+#
+# Copy to apps/client/.env (gitignored) and adjust:
+#     cp apps/client/.env.example apps/client/.env
+#
+# The harness reads .env from its own directory (apps/client) via dotenv, so
+# this file must live here, not at the repo root. `pnpm client` runs from here.
+#
+# The values below are tuned for LOCAL DEVELOPMENT alongside the rssCloud hub
+# (apps/server), which listens on http://localhost:5337 by default.
+
+# --- Harness identity -------------------------------------------------------
+# The hostname/port this harness advertises for its own callbacks and test
+# feeds. Keep PORT matching whatever you actually run it on.
+DOMAIN=localhost
+PORT=9000
+
+# --- Default hub / WebSub target --------------------------------------------
+# Where actions go when the UI's server/hub override field is left blank.
+# Overridden per-action at runtime by that field — this is just the default
+# (e.g. for testing this repo's own hub locally).
+HUB_SERVER_URL=http://localhost:5337
+
+# --- SSRF egress guard: allow loopback for local dev ------------------------
+# The egress guard is ALWAYS ON and refuses loopback/private targets by
+# default (feed discovery, and every pleaseNotify/ping/hub.* call this harness
+# makes). For local dev the harness must reach the hub on loopback.
+#
+# >>> PRODUCTION: delete this line before deploying publicly. This harness is
+# >>> meant to hit arbitrary third-party feeds/hubs when deployed live —
+# >>> loopback exemptions have no place there.
+CLIENT_FETCH_ALLOW_CIDRS=127.0.0.0/8,::1/128
+
+# --- Optional overrides (defaults shown; uncomment to change) --------------
+# REQUEST_TIMEOUT=4000                 # outbound fetch timeout (ms), SSRF-guarded
+# SESSION_CALLBACK_IDLE_MS=3600000     # 1h — incoming callbacks 404 past this idle window
+# SESSION_GC_IDLE_MS=86400000          # 24h — a session is fully evicted from memory past this
+# SESSION_GC_INTERVAL_MS=900000        # 15m — how often the GC sweep runs

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -23,9 +23,9 @@ RUN pnpm install --frozen-lockfile --filter "@rsscloud/client-app..." --prod --i
 
 FROM dependencies AS runtime
 
-COPY apps/client apps/client
-COPY --from=build /app/packages/xml-rpc/dist packages/xml-rpc/dist
-COPY --from=build /app/packages/core/dist packages/core/dist
+COPY --chown=node:node apps/client apps/client
+COPY --from=build --chown=node:node /app/packages/xml-rpc/dist packages/xml-rpc/dist
+COPY --from=build --chown=node:node /app/packages/core/dist packages/core/dist
 
 WORKDIR /app/apps/client
 
@@ -34,5 +34,10 @@ WORKDIR /app/apps/client
 # This harness holds no persistent state to volume-mount: sessions live only
 # in memory for the process lifetime.
 EXPOSE 9000
+
+# node:22 ships a pre-created, unprivileged `node` user (uid 1000) for
+# exactly this purpose — the app never writes to disk, so it only ever needs
+# read access to what was just copied in.
+USER node
 
 CMD ["node", "--use_strict", "index.js"]

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:22 AS base
+
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/client/package.json apps/client/
+COPY packages/xml-rpc/package.json packages/xml-rpc/
+COPY packages/core/package.json packages/core/
+
+# Build the workspace packages (TS → CJS/ESM dist) the harness consumes.
+FROM base AS build
+
+COPY packages/xml-rpc packages/xml-rpc
+COPY packages/core packages/core
+RUN pnpm install --frozen-lockfile --filter "@rsscloud/core..."
+RUN pnpm --filter "@rsscloud/core..." run build
+
+FROM base AS dependencies
+
+RUN pnpm install --frozen-lockfile --filter "@rsscloud/client-app..." --prod --ignore-scripts
+
+FROM dependencies AS runtime
+
+COPY apps/client apps/client
+COPY --from=build /app/packages/xml-rpc/dist packages/xml-rpc/dist
+COPY --from=build /app/packages/core/dist packages/core/dist
+
+WORKDIR /app/apps/client
+
+# Default listen port (config.js's PORT default). Documentation only —
+# override PORT at runtime and publish the matching port if you change it.
+# This harness holds no persistent state to volume-mount: sessions live only
+# in memory for the process lifetime.
+EXPOSE 9000
+
+CMD ["node", "--use_strict", "index.js"]

--- a/apps/client/README.md
+++ b/apps/client/README.md
@@ -1,19 +1,34 @@
 # @rsscloud/client-app
 
-A private, interactive **dev harness** for the [rssCloud](https://github.com/rsscloud/rsscloud-server)
-notification protocol — the subscriber + publisher end, the mirror of `@rsscloud/core`
-(the hub end). It is **not published**; it exists to exercise a running rssCloud server
-by hand.
+An interactive **test harness** for the [rssCloud](https://github.com/rsscloud/rsscloud-server)
+notification protocol and [WebSub](https://www.w3.org/TR/websub/) — the subscriber +
+publisher end, the mirror of `@rsscloud/core` (the hub end). Unlike most of this monorepo
+it's designed to be deployable as a **public utility**: it can test a hub running locally,
+a hub deployed live, or any third party's rssCloud/WebSub implementation.
 
-The Express app ([`client.js`](client.js)) serves a **Subscribe/Ping UI** with a live
-**request log**, and hosts the callback endpoint a hub notifies. It speaks both the
-classic rssCloud protocol **and** [WebSub](https://www.w3.org/TR/websub/): the UI has a
-separate WebSub control set (subscribe/unsubscribe/publish, with optional
-`lease_seconds` and `secret`), the served feed advertises the hub via
-`<atom:link rel="hub">`, and the WebSub callback echoes the intent-verification
-challenge and reports the hub's `X-Hub-Signature` (with a valid/invalid verdict) on
-content distribution. All the protocol wire work lives in [`lib/`](lib/) and is
-reusable on its own.
+The Express app ([`client.js`](client.js)) serves one unified control box — pick a protocol
+(rssCloud REST, rssCloud XML-RPC, or WebSub), point it at this harness's own test feed or an
+arbitrary external one, and Subscribe/Ping/Publish/Unsubscribe. Every action is asynchronous
+(no page navigation); the outcome — and everything this harness receives — shows up as a
+combined, live traffic log via [`@andrewshell/socklog`](https://www.npmjs.com/package/@andrewshell/socklog).
+All the protocol wire work lives in [`lib/`](lib/) and is reusable on its own.
+
+## Sessions
+
+Visiting `/` mints a session id and redirects to `/s/<id>` — that path prefix is the root
+for everything this browser session does: the UI, its test feed(s), and every callback route
+a hub calls back into (`/notify`, `/RPC2`, `/websub-callback`). This keeps concurrent public
+users' logs, feeds, and subscriptions from ever crossing.
+
+A session's callback/feed routes 404 once it's gone `SESSION_CALLBACK_IDLE_MS` (default 1h)
+without an outgoing action — a hub that keeps probing a long-abandoned subscription gets
+nothing back. The UI itself keeps working past that point (acting again resumes it). A
+session is fully evicted from memory after `SESSION_GC_IDLE_MS` (default 24h) of inactivity,
+independent of the callback cutoff, so a long-running public deployment doesn't leak memory.
+
+Both cutoffs are suspended while a session has a live socklog connection — leaving the page
+open (e.g. watching an external feed overnight) counts as active use on its own, even with no
+button clicked, so its callback surface stays reachable and it's never evicted.
 
 ## Running
 
@@ -30,32 +45,61 @@ pnpm --filter @rsscloud/client-app run dev    # watch mode
 pnpm --filter @rsscloud/client-app start      # one-shot
 ```
 
-It listens on `PORT`, advertises itself as `DOMAIN`, and targets a hub at
-`http://localhost:5337`. Requires Node 22+ (uses the global `fetch`).
+Copy `.env.example` to `.env` and adjust — the defaults target a hub at
+`http://localhost:5337` (this repo's own server, run locally) with loopback exempted from
+the outbound SSRF guard for local dev. See `.env.example` for the full list of env vars
+(`DOMAIN`, `PORT`, `HUB_SERVER_URL`, `CLIENT_FETCH_ALLOW_CIDRS`, `REQUEST_TIMEOUT`,
+`SESSION_CALLBACK_IDLE_MS`, `SESSION_GC_IDLE_MS`, `SESSION_GC_INTERVAL_MS`). Requires Node 22+.
 
-| Env var  | Default     | Purpose                                   |
-| -------- | ----------- | ----------------------------------------- |
-| `PORT`   | `9000`      | port the harness listens on               |
-| `DOMAIN` | `localhost` | host it advertises as the callback domain |
+Every outbound call this harness makes (feed discovery, pleaseNotify/ping, WebSub `hub.*`) is
+routed through the same SSRF-guarded fetch `@rsscloud/core` gives the hub server — refusing
+loopback/private/link-local targets by default, since a public deployment lets any visitor
+make it originate arbitrary requests. `CLIENT_FETCH_ALLOW_CIDRS` re-enables loopback for local
+dev; delete it before deploying publicly.
+
+## Docker
+
+```bash
+docker build -f apps/client/Dockerfile -t rsscloud-client .
+docker run -p 9000:9000 --env-file apps/client/.env rsscloud-client
+```
+
+See [`examples/dockge/compose.yaml`](../../examples/dockge/compose.yaml) for a stack pairing
+this harness with the hub server.
 
 ## The `lib/` API
 
 `require('./lib')` exposes these helpers (CommonJS):
 
-- **`createRssCloudClient({ serverUrl, fetch? })`** — send `pleaseNotify` (subscribe)
-  and `ping` (publish) to a hub over an injectable `fetch`. Returns `{ pleaseNotify, ping }`.
-- **`createWebSubClient({ serverUrl, path?, fetch? })`** — send WebSub `hub.*` requests
-  to a hub's front door (`path` defaults to `/websub`). Returns
-  `{ subscribe, unsubscribe, publish }`; each resolves to the hub's raw reply
-  (`{ status, body }`) and does **not** throw on a non-2xx.
+- **`createRssCloudClient({ serverUrl, fetch? })`** — send `pleaseNotify` (subscribe) and
+  `ping` (publish) to a hub over an injectable `fetch`. Returns `{ pleaseNotify, ping }`.
+- **`createWebSubClient({ serverUrl, path?, fetch? })`** — send WebSub `hub.*` requests to a
+  hub's front door (`path` defaults to `/websub`). Returns `{ subscribe, unsubscribe, publish }`;
+  each resolves to the hub's raw reply (`{ status, body }`) and does **not** throw on a non-2xx.
 - **`readVerification(query)`** — given a callback GET's query, return
-  `{ mode, topic, challenge, leaseSeconds }` when it's a WebSub intent-verification
-  request (the subscriber must echo `challenge` verbatim), else `null`.
-- **`renderCloudFeed(feed)`** — emit an RSS 2.0 document carrying the `<cloud>` element
-  that advertises a hub. Pass `hub` (a URL) to also advertise a WebSub hub via
+  `{ mode, topic, challenge, leaseSeconds }` when it's a WebSub intent-verification request
+  (the subscriber must echo `challenge` verbatim), else `null`.
+- **`renderCloudFeed(feed)`** — emit an RSS 2.0 document carrying the `<cloud>` element that
+  advertises a hub. Pass `hub` (a URL) to also advertise a WebSub hub via
   `<atom:link rel="hub">` plus a `rel="self"` link.
-- **`buildNotifyResponse(success)`** — build the XML-RPC notify acknowledgement a
-  subscriber returns to the hub.
+- **`buildNotifyResponse(success)`** — build the XML-RPC notify acknowledgement a subscriber
+  returns to the hub.
+- **`discoverFeed({ url, fetch? })`** — fetch an arbitrary feed URL and report what it
+  advertises: `{ rssCloud: {domain,port,path,registerProcedure,protocol} | null, webSub:
+  {hubUrl} | null, error? }`. Backs the UI's "enter a feed URL" discovery action.
+- **`parseFeedDiscovery(xmlText)`** — the parsing half of `discoverFeed`, given an
+  already-fetched body.
+
+Two more app-root modules (not part of the portable `lib/` barrel, since they're
+Express/`ws`-coupled):
+
+- **`lib/session-store.js`**'s `createSessionStore({ now?, idGenerator? })` — the in-memory
+  per-session state (request log, feed items, WebSub secrets, idle tracking) described above.
+- **`session-sockets.js`**'s `createSessionSockets({ sessionStore })` — the per-session
+  socklog WebSocket feed (`/s/:id/logs`), returning `{ attach(server), broadcast(sessionId,
+  entry) }`.
+- **`lib/guarded-fetch.js`**'s `createGuardedFetch({ allowCidrs?, timeoutMs? })` — the
+  SSRF-guarded fetch described above.
 
 ### WebSub
 
@@ -65,13 +109,13 @@ const { createWebSubClient } = require('./lib');
 const hub = createWebSubClient({ serverUrl: 'http://localhost:5337' });
 
 await hub.subscribe({
-    callbackUrl: 'http://localhost:9000/websub-callback',
-    topicUrl: 'http://localhost:9000/rss-01.xml',
+    callbackUrl: 'http://localhost:9000/s/<session-id>/websub-callback',
+    topicUrl: 'http://localhost:9000/s/<session-id>/rss-01.xml',
     leaseSeconds: 3600, // optional; the hub clamps to its configured bounds
     secret: 's3cr3t' // optional; opts into a signed X-Hub-Signature delivery
 });
 
-await hub.publish({ topicUrl: 'http://localhost:9000/rss-01.xml' }); // hub.mode=publish
+await hub.publish({ topicUrl: 'http://localhost:9000/s/<session-id>/rss-01.xml' }); // hub.mode=publish
 await hub.unsubscribe({ callbackUrl: '…', topicUrl: '…' });
 ```
 
@@ -89,12 +133,11 @@ const { status, body } = await client.pleaseNotify({
 });
 ```
 
-`callback.domain` is optional and selects the hub's verification flow: when given, the
-hub verifies against that host (with a challenge for `http-post`/`https-post`); when
-omitted, the hub uses the caller's address. `pleaseNotify` resolves to the hub's raw
-reply (`{ status, body }`) and does **not** throw on a non-2xx — inspect `status`
-yourself. Pass `protocol: 'xml-rpc'` to subscribe over the `/RPC2` front door instead
-of REST.
+`callback.domain` is optional and selects the hub's verification flow: when given, the hub
+verifies against that host (with a challenge for `http-post`/`https-post`); when omitted, the
+hub uses the caller's address. `pleaseNotify` resolves to the hub's raw reply
+(`{ status, body }`) and does **not** throw on a non-2xx — inspect `status` yourself. Pass
+`protocol: 'xml-rpc'` to subscribe over the `/RPC2` front door instead of REST.
 
 ### Ping
 
@@ -105,4 +148,16 @@ const client = createRssCloudClient({ serverUrl: 'http://localhost:5337' });
 
 await client.ping({ feedUrl: 'https://feed.example/rss' }); // REST /ping
 await client.ping({ transport: 'xml-rpc', feedUrl: '…' }); // /RPC2
+```
+
+### Feed discovery
+
+```js
+const { discoverFeed } = require('./lib');
+
+const { rssCloud, webSub, error } = await discoverFeed({
+    url: 'https://feed.example/rss'
+});
+// rssCloud: { domain, port, path, registerProcedure, protocol } | null
+// webSub:   { hubUrl } | null
 ```

--- a/apps/client/client.hub-config.test.js
+++ b/apps/client/client.hub-config.test.js
@@ -1,0 +1,19 @@
+// Isolated from client.test.js: HUB_SERVER_URL must be set before config.js
+// (required transitively by client.js) reads process.env, and config.js is a
+// module-level singleton — this can only be exercised in its own process,
+// which `node --test` already gives each file.
+process.env.HUB_SERVER_URL = 'http://hub.example.org:8080';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createApp } = require('./client');
+const request = require('supertest');
+
+test('the served test feed\'s <cloud> element derives domain/port from HUB_SERVER_URL', async() => {
+    const app = createApp();
+
+    await request(app).get('/s/cloud-config-session');
+    const res = await request(app).get('/s/cloud-config-session/rss-01.xml');
+
+    assert.match(res.text, /<cloud domain="hub\.example\.org" port="8080"/);
+});

--- a/apps/client/client.js
+++ b/apps/client/client.js
@@ -1,5 +1,6 @@
 const bodyParser = require('body-parser'),
     crypto = require('crypto'),
+    { URL } = require('url'),
     express = require('express'),
     morgan = require('morgan'),
     config = require('./config'),
@@ -23,6 +24,11 @@ const bodyParser = require('body-parser'),
 
 // The hub's WebSub front door, advertised in feeds via <atom:link rel="hub">.
 const hubUrl = `${config.hubServerUrl}/websub`;
+// The hub's origin, decomposed for the <cloud> element's domain/port — its
+// XML-RPC front door is always /RPC2, the rssCloud convention.
+const hubOrigin = new URL(config.hubServerUrl);
+const hubPort =
+    Number(hubOrigin.port) || (hubOrigin.protocol === 'https:' ? 443 : 80);
 
 // This session's callback URL the hub notifies for WebSub content
 // distribution and intent verification.
@@ -229,6 +235,19 @@ function createApp({
 } = {}) {
     const { attach, broadcast } = createSessionSockets({ sessionStore });
 
+    // Every outbound action broadcasts its request as it's about to fire;
+    // routing that broadcast through here keeps the session's idle clock
+    // (lastOutgoingAt) in sync with actual activity, so requireLiveSession
+    // doesn't treat a session mid-use as abandoned.
+    function broadcastOutgoingRequest(sessionId, entry) {
+        sessionStore.touchOutgoing(sessionId);
+        broadcast(sessionId, {
+            ...entry,
+            direction: 'outgoing',
+            phase: 'request'
+        });
+    }
+
     // UI/action routes create a session on demand.
     function ensureSession(req, res, next) {
         req.session = sessionStore.getOrCreate(req.params.sessionId);
@@ -359,10 +378,8 @@ function createApp({
         const { feedUrl } = req.body;
         const logId = crypto.randomUUID();
 
-        broadcast(sessionId, {
+        broadcastOutgoingRequest(sessionId, {
             id: logId,
-            direction: 'outgoing',
-            phase: 'request',
             timestamp: new Date().toISOString(),
             method: 'GET',
             url: feedUrl,
@@ -402,11 +419,12 @@ function createApp({
         const feedUrl = resolveFeedUrl(sessionId, req.body);
         const logId = crypto.randomUUID();
 
-        async function logAndRespond(action, targetUrl, requestBody, call) {
-            broadcast(sessionId, {
+        // `onSuccess`, when given, runs only once `call()` resolves without
+        // throwing — session state (e.g. the WebSub secret) must never be
+        // mutated on the strength of a request that might still fail.
+        async function logAndRespond(action, targetUrl, requestBody, call, onSuccess) {
+            broadcastOutgoingRequest(sessionId, {
                 id: logId,
-                direction: 'outgoing',
-                phase: 'request',
                 timestamp: new Date().toISOString(),
                 method: 'POST',
                 url: targetUrl,
@@ -414,6 +432,7 @@ function createApp({
             });
             try {
                 const result = await call();
+                onSuccess?.(result);
                 broadcast(sessionId, {
                     id: logId,
                     direction: 'outgoing',
@@ -443,19 +462,22 @@ function createApp({
             await logAndRespond(
                 'websub-subscribe',
                 serverOverride || hubUrl,
-                { topicUrl: feedUrl, leaseSeconds, secret },
+                // Redact the secret in the logged/broadcast copy — it's still
+                // sent verbatim to the hub below, just never echoed into the
+                // traffic log or session.requestLog.
+                { topicUrl: feedUrl, leaseSeconds, secret: secret ? '(redacted)' : undefined },
+                () => hub.subscribe({
+                    callbackUrl: webSubCallbackUrl(sessionId),
+                    topicUrl: feedUrl,
+                    leaseSeconds,
+                    secret
+                }),
                 () => {
                     if (secret) {
                         req.session.webSubSecrets[feedUrl] = secret;
                     } else {
                         delete req.session.webSubSecrets[feedUrl];
                     }
-                    return hub.subscribe({
-                        callbackUrl: webSubCallbackUrl(sessionId),
-                        topicUrl: feedUrl,
-                        leaseSeconds,
-                        secret
-                    });
                 }
             );
             return;
@@ -492,18 +514,14 @@ function createApp({
         const feedUrl = resolveFeedUrl(sessionId, req.body);
         const logId = crypto.randomUUID();
 
-        delete req.session.webSubSecrets[feedUrl];
-
         const hub = createWebSubClient({
             serverUrl: serverOverride || config.hubServerUrl,
             path: serverOverride ? '' : undefined,
             fetch
         });
 
-        broadcast(sessionId, {
+        broadcastOutgoingRequest(sessionId, {
             id: logId,
-            direction: 'outgoing',
-            phase: 'request',
             timestamp: new Date().toISOString(),
             method: 'POST',
             url: serverOverride || hubUrl,
@@ -515,6 +533,9 @@ function createApp({
                 callbackUrl: webSubCallbackUrl(sessionId),
                 topicUrl: feedUrl
             });
+            // Only drop the stored secret once the hub has actually
+            // acknowledged the unsubscribe — a failed call shouldn't lose it.
+            delete req.session.webSubSecrets[feedUrl];
             broadcast(sessionId, {
                 id: logId,
                 direction: 'outgoing',
@@ -560,10 +581,8 @@ function createApp({
             fetch
         });
 
-        broadcast(sessionId, {
+        broadcastOutgoingRequest(sessionId, {
             id: logId,
-            direction: 'outgoing',
-            phase: 'request',
             timestamp: new Date().toISOString(),
             method: 'POST',
             url: serverOverride || hubUrl,
@@ -624,10 +643,8 @@ function createApp({
             transport: protocol === 'rsscloud-xml-rpc' ? 'xml-rpc' : 'rest'
         };
 
-        broadcast(sessionId, {
+        broadcastOutgoingRequest(sessionId, {
             id: logId,
-            direction: 'outgoing',
-            phase: 'request',
             timestamp: new Date().toISOString(),
             method: 'POST',
             url: serverOverride || config.hubServerUrl,
@@ -713,8 +730,8 @@ function createApp({
             link: feedUrl,
             description: 'Test feed for rssCloud',
             cloud: {
-                domain: 'localhost',
-                port: 5337,
+                domain: hubOrigin.hostname,
+                port: hubPort,
                 path: '/RPC2',
                 registerProcedure: 'rssCloud.pleaseNotify',
                 protocol: 'xml-rpc'

--- a/apps/client/client.js
+++ b/apps/client/client.js
@@ -2,62 +2,38 @@ const bodyParser = require('body-parser'),
     crypto = require('crypto'),
     express = require('express'),
     morgan = require('morgan'),
-    packageJson = require('./package.json'),
+    config = require('./config'),
+    { createSessionStore } = require('./lib/session-store'),
+    { createGuardedFetch } = require('./lib/guarded-fetch'),
+    { createSessionSockets } = require('./session-sockets'),
     {
         createRssCloudClient,
         createWebSubClient,
         readVerification,
         buildNotifyResponse,
-        renderCloudFeed
+        renderCloudFeed,
+        discoverFeed
     } = require('./lib'),
     textParser = bodyParser.text({ type: '*/xml' }),
     // Content distribution arrives with the origin feed's Content-Type relayed
     // verbatim, so the callback parses any media type as a raw string to log it.
     rawTextParser = bodyParser.text({ type: () => true }),
-    urlencodedParser = bodyParser.urlencoded({ extended: false });
-
-// Simple config utility
-function getConfig(key, defaultValue) {
-    return process.env[key] ?? defaultValue;
-}
-
-function getNumericConfig(key, defaultValue) {
-    const value = process.env[key];
-    return value ? parseInt(value, 10) : defaultValue;
-}
-
-const clientConfig = {
-    appName: 'rssCloudClient',
-    appVersion: packageJson.version,
-    domain: getConfig('DOMAIN', 'localhost'),
-    port: getNumericConfig('PORT', 9000),
-    rsscloudServer: 'http://localhost:5337'
-};
+    urlencodedParser = bodyParser.urlencoded({ extended: false }),
+    jsonParser = bodyParser.json();
 
 // The hub's WebSub front door, advertised in feeds via <atom:link rel="hub">.
-clientConfig.hubUrl = `${clientConfig.rsscloudServer}/websub`;
-// The path the hub verifies and delivers WebSub content to on this harness.
-const WEBSUB_CALLBACK_PATH = '/websub-callback';
+const hubUrl = `${config.hubServerUrl}/websub`;
 
-// All protocol wire work (pleaseNotify/ping calls, WebSub hub.* calls, the
-// XML-RPC notify ack, and <cloud>/atom feed rendering) lives in ./lib; this file
-// is just the UI.
-const client = createRssCloudClient({ serverUrl: clientConfig.rsscloudServer });
-const webSubClient = createWebSubClient({
-    serverUrl: clientConfig.rsscloudServer
-});
+// This session's callback URL the hub notifies for WebSub content
+// distribution and intent verification.
+function webSubCallbackUrl(sessionId) {
+    return `http://${config.domain}:${config.port}/s/${sessionId}/websub-callback`;
+}
 
-// In-memory data stores (reset on restart)
-const requestLog = [];
-const feedItems = {};
-// Secrets supplied on WebSub subscribe, keyed by topic URL, so the callback can
-// check the hub's X-Hub-Signature on delivery.
-const webSubSecrets = {};
-const MAX_LOG_ENTRIES = 100;
-
-// The callback URL this harness registers with the hub for a feed.
-function webSubCallbackUrl() {
-    return `http://${clientConfig.domain}:${clientConfig.port}${WEBSUB_CALLBACK_PATH}`;
+// Build the feed URL an action targets: the caller's own external feedUrl
+// when given (subscriber mode), else this session's own test feed.
+function resolveFeedUrl(sessionId, { feedUrl, feedName }) {
+    return feedUrl || `http://${config.domain}:${config.port}/s/${sessionId}/${feedName || 'rss-01.xml'}`;
 }
 
 // Pull the topic URL out of a delivery's Link header (`<url>; rel="self"`).
@@ -67,9 +43,10 @@ function selfLink(link) {
 }
 
 // Verify a relayed X-Hub-Signature (`<algo>=<hex>`) against the body using the
-// secret we subscribed with. Returns a human-readable verdict for the log.
-function checkSignature(topicUrl, signature, body) {
-    const secret = webSubSecrets[topicUrl];
+// secret this session subscribed with. Returns a human-readable verdict for
+// the log.
+function checkSignature(session, topicUrl, signature, body) {
+    const secret = session.webSubSecrets[topicUrl];
     if (!secret) {
         return 'no stored secret — not verified';
     }
@@ -86,93 +63,6 @@ function checkSignature(topicUrl, signature, body) {
     return expected === digest ? 'valid ✓' : 'INVALID ✗';
 }
 
-let app, server;
-
-console.log(`${clientConfig.appName} ${clientConfig.appVersion}`);
-
-morgan.format('mydate', () => {
-    return new Date()
-        .toLocaleTimeString('en-US', {
-            hour12: false,
-            fractionalSecondDigits: 3
-        })
-        .replace(/:/g, ':');
-});
-
-app = express();
-
-app.use(
-    morgan(
-        '[:mydate] :method :url :status :res[content-length] - :remote-addr - :response-time ms'
-    )
-);
-
-// Handle static files in public directory
-app.use(
-    express.static('public', {
-        dotfiles: 'ignore',
-        maxAge: '1d'
-    })
-);
-
-// Request logging middleware - captures all incoming requests
-app.use((req, res, next) => {
-    // Log request after body is parsed
-    res.on('finish', () => {
-        // Don't log client UI requests to keep log clean
-        if (req.path === '/' && req.method === 'GET') {
-            return;
-        }
-        if (req.path === '/subscribe' || req.path === '/ping-feed') {
-            return;
-        }
-        // WebSub UI actions are outbound; only hub -> harness traffic is logged.
-        if (
-            req.path === '/websub-subscribe' ||
-            req.path === '/websub-unsubscribe' ||
-            req.path === '/websub-publish'
-        ) {
-            return;
-        }
-        if (req.path.startsWith('/.well-known/')) {
-            return;
-        }
-
-        // Surface the WebSub delivery headers so the hub/self links and the
-        // signature (with our verdict) are visible in the log.
-        const headers = {};
-        if (req.headers.link) {
-            headers.Link = req.headers.link;
-        }
-        if (req.headers['x-hub-signature']) {
-            const topic = selfLink(req.headers.link);
-            headers['X-Hub-Signature'] =
-                `${req.headers['x-hub-signature']} (${checkSignature(
-                    topic,
-                    req.headers['x-hub-signature'],
-                    req.body
-                )})`;
-        }
-
-        const logEntry = {
-            timestamp: new Date().toISOString(),
-            method: req.method,
-            url: req.originalUrl,
-            headers: Object.keys(headers).length ? headers : null,
-            body: req.body || null
-        };
-
-        requestLog.unshift(logEntry);
-
-        // Cap the log size
-        if (requestLog.length > MAX_LOG_ENTRIES) {
-            requestLog.pop();
-        }
-    });
-
-    next();
-});
-
 // Helper function to escape HTML entities
 function escapeHtml(text) {
     return text
@@ -183,484 +73,668 @@ function escapeHtml(text) {
         .replace(/'/g, '&#039;');
 }
 
-// Helper function to format request body for display
-function formatBody(body) {
-    if (!body) return '';
-    // If it's a string (e.g., XML), display as-is (escaped)
-    if (typeof body === 'string') {
-        return escapeHtml(body);
-    }
-    // If it's an object (e.g., form data), display as JSON
-    return escapeHtml(JSON.stringify(body));
-}
-
-// Helper function to generate HTML page
-function generateHtmlPage() {
-    const logHtml = requestLog
-        .map(entry => {
-            const bodyDisplay = formatBody(entry.body);
-            const headersDisplay = entry.headers
-                ? Object.entries(entry.headers)
-                    .map(
-                        ([key, value]) =>
-                            `<div class="header"><strong>${escapeHtml(
-                                key
-                            )}:</strong> ${escapeHtml(String(value))}</div>`
-                    )
-                    .join('')
-                : '';
-            return `<div class="log-entry">
-            <span class="method">${entry.method}</span>
-            <span class="url">${escapeHtml(entry.url)}</span>
-            ${headersDisplay ? `<div class="headers">${headersDisplay}</div>` : ''}
-            ${bodyDisplay ? `<pre class="body">${bodyDisplay}</pre>` : ''}
-            <span class="timestamp">${entry.timestamp}</span>
-        </div>`;
-        })
-        .join('\n');
-
+// Render the unified control box + live traffic log for a session.
+// `hubServerUrl`/`hubUrl` prefill the server/hub override field with this
+// harness's own defaults; the Discover action overwrites it client-side.
+function renderPage(sessionId, wsUrl) {
     return `<!DOCTYPE html>
 <html>
 <head>
     <title>rssCloud Test Client</title>
+    <link href="/css/style.css" rel="stylesheet" />
     <style>
-        body {
-            font-family: monospace;
-            max-width: 900px;
-            margin: 20px auto;
-            padding: 0 20px;
+        /* Client-specific additions layered on the shared server stylesheet. */
+        select {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            margin-bottom: 15px;
+            font-size: 16px;
+            background: white;
         }
-        h1 { margin-bottom: 20px; }
         .controls {
-            background: #f5f5f5;
-            padding: 15px;
+            background: #f8f9fa;
+            padding: 20px;
             border-radius: 5px;
-            margin-bottom: 20px;
+            margin: 20px 0;
         }
-        .controls form {
+        .controls fieldset {
+            border: none;
+            padding: 0;
+            margin: 0 0 20px;
+        }
+        .controls fieldset:last-of-type {
+            margin-bottom: 0;
+        }
+        .controls legend {
+            font-weight: bold;
+            color: #2c3e50;
+            padding: 0;
+            margin-bottom: 10px;
+        }
+        .form-row {
             display: flex;
-            align-items: center;
+            gap: 20px;
+            flex-wrap: wrap;
+        }
+        .form-row > label {
+            flex: 1;
+            min-width: 220px;
+        }
+        .input-with-button {
+            display: flex;
+            gap: 10px;
+            align-items: flex-start;
+        }
+        .input-with-button input {
+            flex: 1;
+            margin-bottom: 0;
+        }
+        .actions {
+            display: flex;
             gap: 10px;
             flex-wrap: wrap;
         }
-        .controls label {
-            display: flex;
-            align-items: center;
-            gap: 5px;
-        }
-        .controls input[type="text"] {
-            padding: 8px;
-            font-family: monospace;
-            width: 200px;
-        }
-        .controls button {
-            padding: 8px 16px;
-            cursor: pointer;
-            font-family: monospace;
-        }
-        .log-container {
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-        .log-entry {
-            padding: 10px;
-            border-bottom: 1px solid #eee;
-        }
-        .log-entry:last-child {
-            border-bottom: none;
-        }
-        .method {
-            display: inline-block;
-            width: 50px;
-            font-weight: bold;
-            color: #0066cc;
-        }
-        .url {
-            color: #333;
-        }
-        .body {
-            margin: 5px 0 5px 55px;
-            padding: 5px;
-            background: #f9f9f9;
-            font-size: 12px;
-            overflow-x: auto;
-        }
-        .timestamp {
-            display: block;
-            margin-left: 55px;
-            color: #999;
-            font-size: 11px;
-        }
-        .empty-log {
-            padding: 20px;
-            text-align: center;
-            color: #999;
-        }
-        .result {
-            margin-top: 10px;
-            padding: 10px;
-            border-radius: 5px;
-        }
-        .result.success { background: #d4edda; }
-        .result.error { background: #f8d7da; }
-        .headers {
-            margin: 5px 0 5px 55px;
-            font-size: 11px;
-            color: #555;
-        }
-        .header { word-break: break-all; }
-        .controls h3 {
-            margin: 0 0 10px;
-            font-size: 13px;
-            color: #666;
-        }
-        .controls + .controls { margin-top: -10px; }
     </style>
 </head>
-<body>
+<body data-session-id="${escapeHtml(sessionId)}">
     <h1>rssCloud Test Client</h1>
 
     <div class="controls">
-        <h3>rssCloud</h3>
-        <form method="POST" id="actionForm">
-            <label>
-                <input type="checkbox" name="xmlrpc" id="xmlrpc">
-                XML-RPC
+        <fieldset>
+            <legend>Target</legend>
+            <div class="form-row">
+                <label for="protocol">
+                    Protocol
+                    <select id="protocol">
+                        <option value="rsscloud-rest">rssCloud REST</option>
+                        <option value="rsscloud-xml-rpc">rssCloud XML-RPC</option>
+                        <option value="websub">WebSub</option>
+                    </select>
+                </label>
+                <label for="serverOverride">
+                    Server/hub override
+                    <input type="text" id="serverOverride" placeholder="${escapeHtml(config.hubServerUrl)}">
+                </label>
+            </div>
+        </fieldset>
+
+        <fieldset>
+            <legend>Feed</legend>
+            <label for="feedUrl">
+                Feed URL (external — leave blank to use this harness's own test feed)
             </label>
-            <input type="text" name="feedName" id="feedName" value="rss-01.xml" placeholder="Feed name">
-            <button type="submit" formaction="/subscribe">Subscribe</button>
-            <button type="submit" formaction="/ping-feed">Ping</button>
-        </form>
+            <div class="input-with-button">
+                <input type="text" id="feedUrl" placeholder="https://example.com/feed.xml">
+                <button type="button" id="discoverButton">Discover</button>
+            </div>
+            <label for="feedName">
+                Feed name (own test feed)
+                <input type="text" id="feedName" value="rss-01.xml">
+            </label>
+        </fieldset>
+
+        <fieldset class="websub-only">
+            <legend>WebSub options</legend>
+            <div class="form-row">
+                <label for="leaseSeconds">
+                    lease_seconds
+                    <input type="text" id="leaseSeconds" placeholder="optional">
+                </label>
+                <label for="secret">
+                    secret
+                    <input type="text" id="secret" placeholder="optional">
+                </label>
+            </div>
+        </fieldset>
+
+        <div class="actions">
+            <button type="button" id="subscribeButton">Subscribe</button>
+            <button type="button" id="unsubscribeButton" class="websub-only">Unsubscribe</button>
+            <button type="button" id="pingButton" class="rsscloud-only">Ping</button>
+            <button type="button" id="publishButton" class="websub-only">Publish</button>
+        </div>
     </div>
 
-    <div class="controls">
-        <h3>WebSub</h3>
-        <form method="POST" id="websubForm">
-            <input type="text" name="feedName" value="rss-01.xml" placeholder="Feed name">
-            <input type="text" name="leaseSeconds" placeholder="lease_seconds (optional)">
-            <input type="text" name="secret" placeholder="secret (optional)">
-            <button type="submit" formaction="/websub-subscribe">Subscribe</button>
-            <button type="submit" formaction="/websub-unsubscribe">Unsubscribe</button>
-            <button type="submit" formaction="/websub-publish">Publish</button>
-        </form>
+    <h2>Traffic Log</h2>
+    <p class="feed-url">Log stream: <code>${escapeHtml(wsUrl)}</code></p>
+    <script type="module">
+        import 'https://esm.sh/@andrewshell/socklog';
+        const viewer = document.getElementById('viewer');
+        const controls = document.getElementById('controls');
+        controls.store = viewer.getStore();
+    </script>
+    <div class="log-panel">
+        <socklog-controls id="controls"></socklog-controls>
+        <socklog-viewer id="viewer" url="${escapeHtml(wsUrl)}"></socklog-viewer>
     </div>
 
-    <h2>Incoming Requests</h2>
-    <div class="log-container">
-        ${logHtml || '<div class="empty-log">No requests logged yet. Subscribe to a feed and ping it to see activity.</div>'}
-    </div>
-
-    <p style="margin-top: 20px; color: #666;">
-        Refresh page to see new requests. Server: ${clientConfig.rsscloudServer}
-    </p>
+    <script type="module" src="/app.js"></script>
 </body>
 </html>`;
 }
 
-// Route: Home page with UI
-app.get('/', (req, res) => {
-    res.type('html').send(generateHtmlPage());
-});
+// Build the Express app. `fetch` is injected into the rssCloud/WebSub clients
+// (defaults to the global fetch); `sessionStore` defaults to a fresh
+// in-memory store (defaults let tests inject fakes without touching real
+// process state).
+function createApp({
+    fetch = createGuardedFetch({
+        allowCidrs: config.clientFetchAllowCidrs,
+        timeoutMs: config.requestTimeout
+    }),
+    sessionStore = createSessionStore(),
+    sessionCallbackIdleMs = config.sessionCallbackIdleMs
+} = {}) {
+    const { attach, broadcast } = createSessionSockets({ sessionStore });
 
-// Route: Subscribe to feed notifications
-app.post('/subscribe', urlencodedParser, async(req, res) => {
-    const feedName = req.body.feedName || 'rss-01.xml';
-    const useXmlRpc = req.body.xmlrpc === 'on';
-    const feedUrl = `http://${clientConfig.domain}:${clientConfig.port}/${feedName}`;
-
-    try {
-        const { status, body } = await client.pleaseNotify({
-            protocol: useXmlRpc ? 'xml-rpc' : 'http-post',
-            callback: {
-                domain: clientConfig.domain,
-                port: clientConfig.port,
-                path: useXmlRpc ? '/RPC2' : '/notify'
-            },
-            feedUrl
-        });
-
-        res.type('html').send(`
-            <!DOCTYPE html>
-            <html>
-            <head><title>Subscribe Result</title></head>
-            <body style="font-family: monospace; padding: 20px;">
-                <h2>Subscribe Result</h2>
-                <p><strong>Feed:</strong> ${escapeHtml(feedUrl)}</p>
-                <p><strong>Protocol:</strong> ${useXmlRpc ? 'XML-RPC' : 'REST'}</p>
-                <p><strong>Status:</strong> ${status}</p>
-                <pre style="background: #f5f5f5; padding: 10px; overflow: auto;">${escapeHtml(body)}</pre>
-                <p><a href="/">Back to client</a></p>
-            </body>
-            </html>
-        `);
-    } catch (error) {
-        res.type('html').send(`
-            <!DOCTYPE html>
-            <html>
-            <head><title>Subscribe Error</title></head>
-            <body style="font-family: monospace; padding: 20px;">
-                <h2>Subscribe Error</h2>
-                <p style="color: red;">${escapeHtml(error.message)}</p>
-                <p><a href="/">Back to client</a></p>
-            </body>
-            </html>
-        `);
-    }
-});
-
-// Route: Ping feed (add item and notify)
-app.post('/ping-feed', urlencodedParser, async(req, res) => {
-    const feedName = req.body.feedName || 'rss-01.xml';
-    const useXmlRpc = req.body.xmlrpc === 'on';
-    const feedUrl = `http://${clientConfig.domain}:${clientConfig.port}/${feedName}`;
-
-    // Initialize feed if not exists
-    if (!feedItems[feedName]) {
-        feedItems[feedName] = [{ title: 'initialized', timestamp: new Date() }];
+    // UI/action routes create a session on demand.
+    function ensureSession(req, res, next) {
+        req.session = sessionStore.getOrCreate(req.params.sessionId);
+        next();
     }
 
-    // Add new item with timestamp
-    const now = new Date();
-    feedItems[feedName].unshift({
-        title: `Update at ${now.toISOString()}`,
-        timestamp: now
+    // Machine-to-machine callback/feed routes never create a session, and go
+    // dark (404) once it's idle past sessionCallbackIdleMs — a hub that never
+    // stops probing a long-abandoned subscription shouldn't get a response.
+    // A connected socklog socket overrides this (see session-store.js's
+    // isIdle) — a tab left open overnight watching an external feed is
+    // itself a sign of active use, not abandonment.
+    function requireLiveSession(req, res, next) {
+        if (sessionStore.isIdle(req.params.sessionId, sessionCallbackIdleMs)) {
+            res.status(404).send('Not found');
+            return;
+        }
+        next();
+    }
+
+    const app = express();
+
+    morgan.format('mydate', () => {
+        return new Date()
+            .toLocaleTimeString('en-US', {
+                hour12: false,
+                fractionalSecondDigits: 3
+            })
+            .replace(/:/g, ':');
     });
 
-    try {
-        const { status, body } = await client.ping({
-            feedUrl,
-            transport: useXmlRpc ? 'xml-rpc' : 'rest'
-        });
+    app.use(
+        morgan(
+            '[:mydate] :method :url :status :res[content-length] - :remote-addr - :response-time ms'
+        )
+    );
 
-        res.type('html').send(`
-            <!DOCTYPE html>
-            <html>
-            <head><title>Ping Result</title></head>
-            <body style="font-family: monospace; padding: 20px;">
-                <h2>Ping Result</h2>
-                <p><strong>Feed:</strong> ${escapeHtml(feedUrl)}</p>
-                <p><strong>Protocol:</strong> ${useXmlRpc ? 'XML-RPC' : 'REST'}</p>
-                <p><strong>Items in feed:</strong> ${feedItems[feedName].length}</p>
-                <p><strong>Status:</strong> ${status}</p>
-                <pre style="background: #f5f5f5; padding: 10px; overflow: auto;">${escapeHtml(body)}</pre>
-                <p><a href="/">Back to client</a></p>
-            </body>
-            </html>
-        `);
-    } catch (error) {
-        res.type('html').send(`
-            <!DOCTYPE html>
-            <html>
-            <head><title>Ping Error</title></head>
-            <body style="font-family: monospace; padding: 20px;">
-                <h2>Ping Error</h2>
-                <p style="color: red;">${escapeHtml(error.message)}</p>
-                <p><a href="/">Back to client</a></p>
-            </body>
-            </html>
-        `);
-    }
-});
+    // Handle static files in public directory
+    app.use(
+        express.static('public', {
+            dotfiles: 'ignore',
+            maxAge: '1d'
+        })
+    );
 
-// Render a simple result/error page for a WebSub UI action.
-function webSubResultPage(action, feedUrl, status, body) {
-    return `
-        <!DOCTYPE html>
-        <html>
-        <head><title>WebSub ${action} Result</title></head>
-        <body style="font-family: monospace; padding: 20px;">
-            <h2>WebSub ${action} Result</h2>
-            <p><strong>Topic:</strong> ${escapeHtml(feedUrl)}</p>
-            <p><strong>Status:</strong> ${status} ${status === 202 ? '(accepted — verification/fan-out is async)' : ''}</p>
-            ${body ? `<pre style="background: #f5f5f5; padding: 10px; overflow: auto;">${escapeHtml(body)}</pre>` : ''}
-            <p><a href="/">Back to client</a></p>
-        </body>
-        </html>
-    `;
-}
-
-function webSubErrorPage(action, error) {
-    return `
-        <!DOCTYPE html>
-        <html>
-        <head><title>WebSub ${action} Error</title></head>
-        <body style="font-family: monospace; padding: 20px;">
-            <h2>WebSub ${action} Error</h2>
-            <p style="color: red;">${escapeHtml(error.message)}</p>
-            <p><a href="/">Back to client</a></p>
-        </body>
-        </html>
-    `;
-}
-
-// Parse an optional positive-integer lease from the form, else undefined.
-function parseLease(value) {
-    const seconds = parseInt(value, 10);
-    return Number.isInteger(seconds) && seconds > 0 ? seconds : undefined;
-}
-
-// Route: WebSub subscribe (hub.mode=subscribe)
-app.post('/websub-subscribe', urlencodedParser, async(req, res) => {
-    const feedName = req.body.feedName || 'rss-01.xml';
-    const feedUrl = `http://${clientConfig.domain}:${clientConfig.port}/${feedName}`;
-    const secret = req.body.secret || undefined;
-
-    // Remember the secret so the callback can verify the delivery signature.
-    if (secret) {
-        webSubSecrets[feedUrl] = secret;
-    } else {
-        delete webSubSecrets[feedUrl];
-    }
-
-    try {
-        const { status, body } = await webSubClient.subscribe({
-            callbackUrl: webSubCallbackUrl(),
-            topicUrl: feedUrl,
-            leaseSeconds: parseLease(req.body.leaseSeconds),
-            secret
-        });
-        res.type('html').send(
-            webSubResultPage('Subscribe', feedUrl, status, body)
-        );
-    } catch (error) {
-        res.type('html').send(webSubErrorPage('Subscribe', error));
-    }
-});
-
-// Route: WebSub unsubscribe (hub.mode=unsubscribe)
-app.post('/websub-unsubscribe', urlencodedParser, async(req, res) => {
-    const feedName = req.body.feedName || 'rss-01.xml';
-    const feedUrl = `http://${clientConfig.domain}:${clientConfig.port}/${feedName}`;
-    delete webSubSecrets[feedUrl];
-
-    try {
-        const { status, body } = await webSubClient.unsubscribe({
-            callbackUrl: webSubCallbackUrl(),
-            topicUrl: feedUrl
-        });
-        res.type('html').send(
-            webSubResultPage('Unsubscribe', feedUrl, status, body)
-        );
-    } catch (error) {
-        res.type('html').send(webSubErrorPage('Unsubscribe', error));
-    }
-});
-
-// Route: WebSub publish (hub.mode=publish) — mutate the feed, then notify the
-// hub so it re-fetches and fans the change out to subscribers.
-app.post('/websub-publish', urlencodedParser, async(req, res) => {
-    const feedName = req.body.feedName || 'rss-01.xml';
-    const feedUrl = `http://${clientConfig.domain}:${clientConfig.port}/${feedName}`;
-
-    if (!feedItems[feedName]) {
-        feedItems[feedName] = [{ title: 'initialized', timestamp: new Date() }];
-    }
-    const now = new Date();
-    feedItems[feedName].unshift({
-        title: `Update at ${now.toISOString()}`,
-        timestamp: now
+    // Route: mint a session id and hand the browser off to it.
+    app.get('/', (req, res) => {
+        res.redirect(302, `/s/${crypto.randomUUID()}`);
     });
 
-    try {
-        const { status, body } = await webSubClient.publish({
-            topicUrl: feedUrl
-        });
-        res.type('html').send(
-            webSubResultPage('Publish', feedUrl, status, body)
-        );
-    } catch (error) {
-        res.type('html').send(webSubErrorPage('Publish', error));
-    }
-});
+    const sessionRouter = express.Router({ mergeParams: true });
 
-// Route: WebSub intent verification — the hub GETs the callback with a
-// hub.challenge the subscriber must echo verbatim to confirm the subscription.
-app.get(WEBSUB_CALLBACK_PATH, (req, res) => {
-    const verification = readVerification(req.query);
-    if (verification) {
-        res.send(verification.challenge);
-        return;
-    }
-    res.status(404).send('Not a WebSub verification');
-});
-
-// Route: WebSub content distribution — the hub POSTs the full feed body here.
-// The request-logging middleware records the body, the hub/self Link header, and
-// the signature verdict; we just acknowledge with a 2xx.
-app.post(WEBSUB_CALLBACK_PATH, rawTextParser, (req, res) => {
-    res.status(204).end();
-});
-
-// Route: Handle challenge verification for http-post subscriptions
-app.get('/notify', (req, res) => {
-    const challenge = req.query.challenge || '';
-    res.send(challenge);
-});
-
-// Route: Handle HTTP-POST notifications
-app.post('/notify', urlencodedParser, (req, res) => {
-    // Body is already logged by middleware
-    res.send('');
-});
-
-// Route: Handle XML-RPC notifications
-app.post('/RPC2', textParser, (req, res) => {
-    // Body is already logged by middleware; acknowledge with the boolean reply.
-    res.type('text/xml').send(buildNotifyResponse());
-});
-
-// Route: Serve RSS feeds (must be after specific routes)
-app.get('/:feedName', (req, res) => {
-    const feedName = req.params.feedName;
-
-    // Only serve .xml files as RSS feeds
-    if (!feedName.endsWith('.xml')) {
-        res.status(404).send('Not found');
-        return;
-    }
-
-    const items = feedItems[feedName] || [
-        { title: 'initialized', timestamp: new Date() }
-    ];
-    const feedUrl = `http://${clientConfig.domain}:${clientConfig.port}/${feedName}`;
-
-    const rssXml = renderCloudFeed({
-        title: `Test Feed: ${feedName}`,
-        link: feedUrl,
-        description: 'Test feed for rssCloud',
-        cloud: {
-            domain: 'localhost',
-            port: 5337,
-            path: '/RPC2',
-            registerProcedure: 'rssCloud.pleaseNotify',
-            protocol: 'xml-rpc'
-        },
-        hub: clientConfig.hubUrl,
-        items: items.map((item, index) => ({
-            title: item.title,
-            description: `Feed item: ${item.title}`,
-            pubDate: item.timestamp,
-            guid: `${feedName}-${index}`
-        }))
+    // Attach this request's session state, if it exists — never creates one
+    // (ensureSession does that for UI/action routes). May leave req.session
+    // undefined for a callback/feed route on an unknown id; requireLiveSession
+    // gates those routes before their handler or the logging middleware below
+    // ever reads it.
+    sessionRouter.use((req, res, next) => {
+        req.session = sessionStore.get(req.params.sessionId);
+        next();
     });
-    res.type('application/rss+xml').send(rssXml);
-});
 
-server = app
-    .listen(clientConfig.port, () => {
-        const host = clientConfig.domain,
-            port = server.address().port;
+    // Request logging middleware - captures all incoming requests
+    sessionRouter.use((req, res, next) => {
+        res.on('finish', () => {
+            // No session (unknown/idle id on a callback route, already 404'd
+            // by requireLiveSession) — nothing to log against.
+            if (!req.session) {
+                return;
+            }
+            // Don't log client UI requests to keep log clean
+            if (req.path === '/' && req.method === 'GET') {
+                return;
+            }
+            // The browser's own action-trigger POSTs are outbound; the real
+            // hub-bound request/response they cause is already logged
+            // explicitly (with direction: 'outgoing') by the handler itself.
+            if (req.path.startsWith('/actions/')) {
+                return;
+            }
+            if (req.path.startsWith('/.well-known/')) {
+                return;
+            }
 
-        console.log(`Listening at http://${host}:${port}`);
-    })
-    .on('error', error => {
-        switch (error.code) {
-        case 'EADDRINUSE':
-            console.log(
-                `Error: Port ${clientConfig.port} is already in use.`
-            );
-            break;
-        default:
-            console.log(error.code);
+            // Surface the WebSub delivery headers so the hub/self links and
+            // the signature (with our verdict) are visible in the log.
+            const headers = {};
+            if (req.headers.link) {
+                headers.Link = req.headers.link;
+            }
+            if (req.headers['x-hub-signature']) {
+                const topic = selfLink(req.headers.link);
+                headers['X-Hub-Signature'] =
+                    `${req.headers['x-hub-signature']} (${checkSignature(
+                        req.session,
+                        topic,
+                        req.headers['x-hub-signature'],
+                        req.body
+                    )})`;
+            }
+
+            broadcast(req.params.sessionId, {
+                id: crypto.randomUUID(),
+                direction: 'incoming',
+                timestamp: new Date().toISOString(),
+                method: req.method,
+                url: req.originalUrl,
+                headers: Object.keys(headers).length ? headers : null,
+                body: req.body || null
+            });
+        });
+
+        next();
+    });
+
+    // Route: Home page with UI
+    sessionRouter.get('/', ensureSession, (req, res) => {
+        const wsProtocol = req.protocol === 'https' ? 'wss' : 'ws';
+        const wsUrl = `${wsProtocol}://${req.get('host')}/s/${req.params.sessionId}/logs`;
+        res.type('html').send(renderPage(req.params.sessionId, wsUrl));
+    });
+
+    // Route: parse an arbitrary feed URL for rssCloud/WebSub support. Feeds
+    // this outbound fetch through the same SSRF-guarded fetch as every other
+    // action, since the URL is user-supplied.
+    sessionRouter.post('/actions/discover', ensureSession, jsonParser, async(req, res) => {
+        const sessionId = req.params.sessionId;
+        const { feedUrl } = req.body;
+        const logId = crypto.randomUUID();
+
+        broadcast(sessionId, {
+            id: logId,
+            direction: 'outgoing',
+            phase: 'request',
+            timestamp: new Date().toISOString(),
+            method: 'GET',
+            url: feedUrl,
+            body: { action: 'discover', feedUrl }
+        });
+
+        try {
+            const result = await discoverFeed({ url: feedUrl, fetch });
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                body: result
+            });
+            res.json(result);
+        } catch (error) {
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                error: error.message
+            });
+            res.json({ rssCloud: null, webSub: null, error: error.message });
         }
     });
+
+    // Route: unified Subscribe action — branches by the selected protocol.
+    // `server` optionally overrides the target: for rssCloud this is the hub
+    // origin (pleaseNotify/RPC2 base); for WebSub it's the full hub front-door
+    // URL (path defaults to '' so it isn't double-appended).
+    sessionRouter.post('/actions/subscribe', ensureSession, jsonParser, async(req, res) => {
+        const sessionId = req.params.sessionId;
+        const { protocol, server: serverOverride, leaseSeconds, secret } =
+            req.body;
+        const feedUrl = resolveFeedUrl(sessionId, req.body);
+        const logId = crypto.randomUUID();
+
+        async function logAndRespond(action, targetUrl, requestBody, call) {
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'request',
+                timestamp: new Date().toISOString(),
+                method: 'POST',
+                url: targetUrl,
+                body: { action, ...requestBody }
+            });
+            try {
+                const result = await call();
+                broadcast(sessionId, {
+                    id: logId,
+                    direction: 'outgoing',
+                    phase: 'response',
+                    timestamp: new Date().toISOString(),
+                    ...result
+                });
+                res.json(result);
+            } catch (error) {
+                broadcast(sessionId, {
+                    id: logId,
+                    direction: 'outgoing',
+                    phase: 'response',
+                    timestamp: new Date().toISOString(),
+                    error: error.message
+                });
+                res.json({ error: error.message });
+            }
+        }
+
+        if (protocol === 'websub') {
+            const hub = createWebSubClient({
+                serverUrl: serverOverride || config.hubServerUrl,
+                path: serverOverride ? '' : undefined,
+                fetch
+            });
+            await logAndRespond(
+                'websub-subscribe',
+                serverOverride || hubUrl,
+                { topicUrl: feedUrl, leaseSeconds, secret },
+                () => {
+                    if (secret) {
+                        req.session.webSubSecrets[feedUrl] = secret;
+                    } else {
+                        delete req.session.webSubSecrets[feedUrl];
+                    }
+                    return hub.subscribe({
+                        callbackUrl: webSubCallbackUrl(sessionId),
+                        topicUrl: feedUrl,
+                        leaseSeconds,
+                        secret
+                    });
+                }
+            );
+            return;
+        }
+
+        const useXmlRpc = protocol === 'rsscloud-xml-rpc';
+        const rssCloudClient = createRssCloudClient({
+            serverUrl: serverOverride || config.hubServerUrl,
+            fetch
+        });
+        const subscribeParams = {
+            protocol: useXmlRpc ? 'xml-rpc' : 'http-post',
+            callback: {
+                domain: config.domain,
+                port: config.port,
+                path: useXmlRpc
+                    ? `/s/${sessionId}/RPC2`
+                    : `/s/${sessionId}/notify`
+            },
+            feedUrl
+        };
+        await logAndRespond(
+            'pleaseNotify',
+            serverOverride || config.hubServerUrl,
+            subscribeParams,
+            () => rssCloudClient.pleaseNotify(subscribeParams)
+        );
+    });
+
+    // Route: unified Unsubscribe action (WebSub only).
+    sessionRouter.post('/actions/unsubscribe', ensureSession, jsonParser, async(req, res) => {
+        const sessionId = req.params.sessionId;
+        const { server: serverOverride } = req.body;
+        const feedUrl = resolveFeedUrl(sessionId, req.body);
+        const logId = crypto.randomUUID();
+
+        delete req.session.webSubSecrets[feedUrl];
+
+        const hub = createWebSubClient({
+            serverUrl: serverOverride || config.hubServerUrl,
+            path: serverOverride ? '' : undefined,
+            fetch
+        });
+
+        broadcast(sessionId, {
+            id: logId,
+            direction: 'outgoing',
+            phase: 'request',
+            timestamp: new Date().toISOString(),
+            method: 'POST',
+            url: serverOverride || hubUrl,
+            body: { action: 'websub-unsubscribe', topicUrl: feedUrl }
+        });
+
+        try {
+            const result = await hub.unsubscribe({
+                callbackUrl: webSubCallbackUrl(sessionId),
+                topicUrl: feedUrl
+            });
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                ...result
+            });
+            res.json(result);
+        } catch (error) {
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                error: error.message
+            });
+            res.json({ error: error.message });
+        }
+    });
+
+    // Route: unified Publish action (WebSub only). Deliberately accepts only
+    // `feedName` — see the comment on /actions/ping for why.
+    sessionRouter.post('/actions/publish', ensureSession, jsonParser, async(req, res) => {
+        const sessionId = req.params.sessionId;
+        const { feedName = 'rss-01.xml', server: serverOverride } = req.body;
+        const feedUrl = `http://${config.domain}:${config.port}/s/${sessionId}/${feedName}`;
+        const logId = crypto.randomUUID();
+
+        if (!req.session.feedItems[feedName]) {
+            req.session.feedItems[feedName] = [
+                { title: 'initialized', timestamp: new Date() }
+            ];
+        }
+        const now = new Date();
+        req.session.feedItems[feedName].unshift({
+            title: `Update at ${now.toISOString()}`,
+            timestamp: now
+        });
+
+        const hub = createWebSubClient({
+            serverUrl: serverOverride || config.hubServerUrl,
+            path: serverOverride ? '' : undefined,
+            fetch
+        });
+
+        broadcast(sessionId, {
+            id: logId,
+            direction: 'outgoing',
+            phase: 'request',
+            timestamp: new Date().toISOString(),
+            method: 'POST',
+            url: serverOverride || hubUrl,
+            body: { action: 'websub-publish', topicUrl: feedUrl }
+        });
+
+        try {
+            const result = await hub.publish({ topicUrl: feedUrl });
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                ...result
+            });
+            res.json(result);
+        } catch (error) {
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                error: error.message
+            });
+            res.json({ error: error.message });
+        }
+    });
+
+    // Route: unified Ping action. Deliberately accepts only `feedName` (never
+    // an arbitrary feedUrl) — this session can only ever ping/publish a feed
+    // it itself serves, never someone else's; that's the actual enforcement
+    // point for "don't ping/publish someone else's feed" (the UI hiding
+    // these controls in subscriber mode is a client-side mirror of this).
+    sessionRouter.post('/actions/ping', ensureSession, jsonParser, async(req, res) => {
+        const sessionId = req.params.sessionId;
+        const { protocol, feedName = 'rss-01.xml', server: serverOverride } =
+            req.body;
+        const feedUrl = `http://${config.domain}:${config.port}/s/${sessionId}/${feedName}`;
+        const logId = crypto.randomUUID();
+
+        if (!req.session.feedItems[feedName]) {
+            req.session.feedItems[feedName] = [
+                { title: 'initialized', timestamp: new Date() }
+            ];
+        }
+        const now = new Date();
+        req.session.feedItems[feedName].unshift({
+            title: `Update at ${now.toISOString()}`,
+            timestamp: now
+        });
+
+        const rssCloudClient = createRssCloudClient({
+            serverUrl: serverOverride || config.hubServerUrl,
+            fetch
+        });
+        const pingParams = {
+            feedUrl,
+            transport: protocol === 'rsscloud-xml-rpc' ? 'xml-rpc' : 'rest'
+        };
+
+        broadcast(sessionId, {
+            id: logId,
+            direction: 'outgoing',
+            phase: 'request',
+            timestamp: new Date().toISOString(),
+            method: 'POST',
+            url: serverOverride || config.hubServerUrl,
+            body: { action: 'ping', ...pingParams }
+        });
+
+        try {
+            const result = await rssCloudClient.ping(pingParams);
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                ...result
+            });
+            res.json(result);
+        } catch (error) {
+            broadcast(sessionId, {
+                id: logId,
+                direction: 'outgoing',
+                phase: 'response',
+                timestamp: new Date().toISOString(),
+                error: error.message
+            });
+            res.json({ error: error.message });
+        }
+    });
+
+    // Route: WebSub intent verification — the hub GETs the callback with a
+    // hub.challenge the subscriber must echo verbatim to confirm the subscription.
+    sessionRouter.get('/websub-callback', requireLiveSession, (req, res) => {
+        const verification = readVerification(req.query);
+        if (verification) {
+            res.send(verification.challenge);
+            return;
+        }
+        res.status(404).send('Not a WebSub verification');
+    });
+
+    // Route: WebSub content distribution — the hub POSTs the full feed body
+    // here. The request-logging middleware records the body, the hub/self
+    // Link header, and the signature verdict; we just acknowledge with a 2xx.
+    sessionRouter.post('/websub-callback', requireLiveSession, rawTextParser, (req, res) => {
+        res.status(204).end();
+    });
+
+    // Route: Handle challenge verification for http-post subscriptions
+    sessionRouter.get('/notify', requireLiveSession, (req, res) => {
+        const challenge = req.query.challenge || '';
+        res.send(challenge);
+    });
+
+    // Route: Handle HTTP-POST notifications
+    sessionRouter.post('/notify', requireLiveSession, urlencodedParser, (req, res) => {
+        // Body is already logged by middleware
+        res.send('');
+    });
+
+    // Route: Handle XML-RPC notifications
+    sessionRouter.post('/RPC2', requireLiveSession, textParser, (req, res) => {
+        // Body is already logged by middleware; acknowledge with the boolean reply.
+        res.type('text/xml').send(buildNotifyResponse());
+    });
+
+    // Route: Serve RSS feeds (must be after specific routes)
+    sessionRouter.get('/:feedName', requireLiveSession, (req, res) => {
+        const sessionId = req.params.sessionId;
+        const feedName = req.params.feedName;
+
+        // Only serve .xml files as RSS feeds
+        if (!feedName.endsWith('.xml')) {
+            res.status(404).send('Not found');
+            return;
+        }
+
+        const items = req.session.feedItems[feedName] || [
+            { title: 'initialized', timestamp: new Date() }
+        ];
+        const feedUrl = `http://${config.domain}:${config.port}/s/${sessionId}/${feedName}`;
+
+        const rssXml = renderCloudFeed({
+            title: `Test Feed: ${feedName}`,
+            link: feedUrl,
+            description: 'Test feed for rssCloud',
+            cloud: {
+                domain: 'localhost',
+                port: 5337,
+                path: '/RPC2',
+                registerProcedure: 'rssCloud.pleaseNotify',
+                protocol: 'xml-rpc'
+            },
+            hub: hubUrl,
+            items: items.map((item, index) => ({
+                title: item.title,
+                description: `Feed item: ${item.title}`,
+                pubDate: item.timestamp,
+                guid: `${feedName}-${index}`
+            }))
+        });
+        res.type('application/rss+xml').send(rssXml);
+    });
+
+    app.use('/s/:sessionId', sessionRouter);
+
+    app.locals.attachSessionSockets = attach;
+
+    return app;
+}
+
+module.exports = { createApp };

--- a/apps/client/client.test.js
+++ b/apps/client/client.test.js
@@ -1,0 +1,416 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createApp } = require('./client');
+const { createSessionStore } = require('./lib/session-store');
+const request = require('supertest');
+
+test('GET /s/:id/notify 404s once the session has been idle past the callback threshold', async() => {
+    let currentTime = 1000;
+    const sessionStore = createSessionStore({ now: () => currentTime });
+    const app = createApp({ sessionStore, sessionCallbackIdleMs: 500 });
+
+    // Visiting the UI creates the session (lazy getOrCreate), starting its
+    // idle clock at currentTime.
+    await request(app).get('/s/idle-session');
+
+    currentTime += 501;
+
+    const notifyRes = await request(app)
+        .get('/s/idle-session/notify')
+        .query({ challenge: 'abc' });
+    assert.equal(notifyRes.status, 404);
+
+    const homeRes = await request(app).get('/s/idle-session');
+    assert.equal(homeRes.status, 200);
+});
+
+test('GET /s/:id/notify does not 404 past the callback threshold while a socklog socket is connected', async() => {
+    let currentTime = 1000;
+    const sessionStore = createSessionStore({ now: () => currentTime });
+    const app = createApp({ sessionStore, sessionCallbackIdleMs: 500 });
+
+    await request(app).get('/s/watched-session');
+    // Simulate a page left open: a live socklog-viewer connection attached
+    // to the session, same as session-sockets.js tracks on a real one.
+    sessionStore.get('watched-session').sockets.add({
+        readyState: 1,
+        OPEN: 1,
+        send: () => {}
+    });
+
+    currentTime += 501;
+
+    const notifyRes = await request(app)
+        .get('/s/watched-session/notify')
+        .query({ challenge: 'abc' });
+
+    assert.equal(notifyRes.status, 200);
+    assert.equal(notifyRes.text, 'abc');
+});
+
+test('a session evicted by the GC sweep is transparently recreated on the next visit', async() => {
+    let currentTime = 1000;
+    const sessionStore = createSessionStore({ now: () => currentTime });
+    const app = createApp({ sessionStore });
+
+    await request(app).get('/s/gc-session');
+    assert.equal(sessionStore.size(), 1);
+
+    currentTime += 86400001; // past the 24h GC default
+    sessionStore.sweep(86400000);
+    assert.equal(sessionStore.size(), 0);
+
+    const res = await request(app).get('/s/gc-session');
+    assert.equal(res.status, 200);
+    assert.equal(sessionStore.size(), 1);
+});
+
+test('GET / redirects to a fresh /s/<uuid> session URL', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/');
+
+    assert.equal(res.status, 302);
+    assert.match(
+        res.headers.location,
+        /^\/s\/[0-9a-f-]{36}$/
+    );
+});
+
+test('GET /s/:id 200s for a session id never referenced before', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/never-seen-before');
+
+    assert.equal(res.status, 200);
+    assert.match(res.headers['content-type'], /html/);
+});
+
+test('GET /s/:id embeds a socklog-viewer pointed at this session\'s WS log feed', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/my-log-session');
+
+    assert.match(
+        res.text,
+        /<socklog-viewer[^>]*url=['"]ws:\/\/[^'"]*\/s\/my-log-session\/logs['"]/
+    );
+});
+
+test('GET /s/:id renders a unified protocol select and the session id on <body>', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/my-ui-session');
+
+    assert.match(res.text, /<body[^>]*data-session-id=['"]my-ui-session['"]/);
+    assert.match(res.text, /<select[^>]*id=['"]protocol['"]/);
+    assert.match(res.text, /<option value=['"]rsscloud-rest['"]/);
+    assert.match(res.text, /<option value=['"]rsscloud-xml-rpc['"]/);
+    assert.match(res.text, /<option value=['"]websub['"]/);
+});
+
+test('POST /s/:id/actions/subscribe over rsscloud-rest calls pleaseNotify and returns JSON', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 200, text: async() => 'thanks' };
+    };
+    const app = createApp({ fetch });
+
+    const res = await request(app)
+        .post('/s/my-session/actions/subscribe')
+        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body, { status: 200, body: 'thanks' });
+    assert.equal(calls[0].url, 'http://localhost:5337/pleaseNotify');
+    const body = new URLSearchParams(calls[0].init.body);
+    assert.equal(body.get('protocol'), 'http-post');
+    assert.equal(body.get('path'), '/s/my-session/notify');
+});
+
+test('POST /s/:id/actions/subscribe over rsscloud-xml-rpc posts to /RPC2', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 200, text: async() => 'ok' };
+    };
+    const app = createApp({ fetch });
+
+    await request(app)
+        .post('/s/my-session/actions/subscribe')
+        .send({ protocol: 'rsscloud-xml-rpc', feedName: 'rss-01.xml' });
+
+    assert.equal(calls[0].url, 'http://localhost:5337/RPC2');
+});
+
+test('POST /s/:id/actions/subscribe over websub posts hub.mode=subscribe to the hub', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 202, text: async() => '' };
+    };
+    const app = createApp({ fetch });
+
+    const res = await request(app)
+        .post('/s/my-session/actions/subscribe')
+        .send({ protocol: 'websub', feedName: 'rss-01.xml', leaseSeconds: 3600 });
+
+    assert.equal(res.body.status, 202);
+    assert.equal(calls[0].url, 'http://localhost:5337/websub');
+    const body = new URLSearchParams(calls[0].init.body);
+    assert.equal(body.get('hub.mode'), 'subscribe');
+    assert.equal(body.get('hub.lease_seconds'), '3600');
+});
+
+test('POST /s/:id/actions/subscribe honors a server override for rssCloud', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 200, text: async() => 'ok' };
+    };
+    const app = createApp({ fetch });
+
+    await request(app)
+        .post('/s/my-session/actions/subscribe')
+        .send({
+            protocol: 'rsscloud-rest',
+            feedName: 'rss-01.xml',
+            server: 'http://other-hub.example'
+        });
+
+    assert.equal(calls[0].url, 'http://other-hub.example/pleaseNotify');
+});
+
+test('POST /s/:id/actions/subscribe honors a server override for websub (full hub URL, no double path)', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 202, text: async() => '' };
+    };
+    const app = createApp({ fetch });
+
+    await request(app)
+        .post('/s/my-session/actions/subscribe')
+        .send({
+            protocol: 'websub',
+            feedName: 'rss-01.xml',
+            server: 'http://other-hub.example/custom-websub'
+        });
+
+    assert.equal(calls[0].url, 'http://other-hub.example/custom-websub');
+});
+
+test('POST /s/:id/actions/ping calls ping and returns JSON', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 200, text: async() => 'pinged' };
+    };
+    const app = createApp({ fetch });
+
+    const res = await request(app)
+        .post('/s/my-session/actions/ping')
+        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+
+    assert.deepEqual(res.body, { status: 200, body: 'pinged' });
+    assert.equal(calls[0].url, 'http://localhost:5337/ping');
+});
+
+test('POST /s/:id/actions/publish calls hub.mode=publish and returns JSON', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 202, text: async() => '' };
+    };
+    const app = createApp({ fetch });
+
+    const res = await request(app)
+        .post('/s/my-session/actions/publish')
+        .send({ feedName: 'rss-01.xml' });
+
+    assert.equal(res.body.status, 202);
+    assert.equal(calls[0].url, 'http://localhost:5337/websub');
+    const body = new URLSearchParams(calls[0].init.body);
+    assert.equal(body.get('hub.mode'), 'publish');
+});
+
+test('POST /s/:id/actions/unsubscribe calls hub.mode=unsubscribe and returns JSON', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 202, text: async() => '' };
+    };
+    const app = createApp({ fetch });
+
+    const res = await request(app)
+        .post('/s/my-session/actions/unsubscribe')
+        .send({ feedName: 'rss-01.xml' });
+
+    assert.equal(res.body.status, 202);
+    const body = new URLSearchParams(calls[0].init.body);
+    assert.equal(body.get('hub.mode'), 'unsubscribe');
+});
+
+test('POST /s/:id/actions/discover fetches and reports what a feed advertises', async() => {
+    const feedXml = `<?xml version="1.0"?>
+<rss version="2.0">
+<channel><title>t</title><link>http://feed.example/rss</link><description>d</description>
+<cloud domain="hub.example" port="80" path="/RPC2" registerProcedure="rssCloud.pleaseNotify" protocol="xml-rpc" />
+</channel></rss>`;
+    const fetch = async() => ({ status: 200, text: async() => feedXml });
+    const app = createApp({ fetch });
+
+    const res = await request(app)
+        .post('/s/my-session/actions/discover')
+        .send({ feedUrl: 'http://feed.example/rss' });
+
+    assert.equal(res.body.rssCloud.domain, 'hub.example');
+    assert.equal(res.body.webSub, null);
+});
+
+function fakeFetch(status = 200, responseBody = 'OK') {
+    return async() => ({ status, text: async() => responseBody });
+}
+
+test('pinging session A does not affect session B\'s same-named feed', async() => {
+    const app = createApp({ fetch: fakeFetch() });
+
+    // Visiting the UI is what creates a session; a feed/callback route on an
+    // id that was never visited 404s (see the idle-404 tests below).
+    await request(app).get('/s/session-a');
+    await request(app).get('/s/session-b');
+
+    await request(app)
+        .post('/s/session-a/actions/ping')
+        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+
+    const feedA = await request(app).get('/s/session-a/rss-01.xml');
+    const feedB = await request(app).get('/s/session-b/rss-01.xml');
+
+    assert.match(feedA.text, /Update at/);
+    assert.doesNotMatch(feedB.text, /Update at/);
+    assert.match(feedB.text, /initialized/);
+});
+
+test('GET /s/:id/notify echoes the challenge query param', async() => {
+    const app = createApp();
+
+    await request(app).get('/s/my-session');
+
+    const res = await request(app)
+        .get('/s/my-session/notify')
+        .query({ challenge: 'abc123' });
+
+    assert.equal(res.text, 'abc123');
+});
+
+test('without an injected fetch, an outbound call to the default (loopback) hub is SSRF-blocked cleanly, not a crash', async() => {
+    const app = createApp();
+
+    const res = await request(app)
+        .post('/s/my-session/actions/ping')
+        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+
+    assert.equal(res.status, 200);
+    assert.match(res.body.error, /fetch failed/);
+});
+
+test('subscribing logs an outgoing request entry and a paired response entry', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch: fakeFetch(200, 'thanks'), sessionStore });
+    const sessionId = 'log-session';
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/subscribe`)
+        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+
+    const { requestLog } = sessionStore.get(sessionId);
+    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
+
+    assert.equal(outgoing.length, 2);
+    const [responseEntry, requestEntry] = outgoing; // newest-first
+    assert.equal(requestEntry.phase, 'request');
+    assert.equal(responseEntry.phase, 'response');
+    assert.equal(responseEntry.id, requestEntry.id);
+    assert.equal(responseEntry.status, 200);
+    assert.equal(responseEntry.body, 'thanks');
+});
+
+test('pinging logs an outgoing request entry and a paired response entry', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch: fakeFetch(200, 'ok'), sessionStore });
+    const sessionId = 'ping-log-session';
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/ping`)
+        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+
+    const { requestLog } = sessionStore.get(sessionId);
+    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
+
+    assert.equal(outgoing.length, 2);
+    const [responseEntry, requestEntry] = outgoing;
+    assert.equal(requestEntry.phase, 'request');
+    assert.equal(responseEntry.phase, 'response');
+    assert.equal(responseEntry.id, requestEntry.id);
+    assert.equal(responseEntry.status, 200);
+});
+
+test('websub-subscribe logs an outgoing request entry and a paired response entry', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch: fakeFetch(202, ''), sessionStore });
+    const sessionId = 'websub-log-session';
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/subscribe`)
+        .send({ protocol: 'websub', feedName: 'rss-01.xml' });
+
+    const { requestLog } = sessionStore.get(sessionId);
+    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
+
+    assert.equal(outgoing.length, 2);
+    const [responseEntry, requestEntry] = outgoing;
+    assert.equal(requestEntry.phase, 'request');
+    assert.equal(responseEntry.phase, 'response');
+    assert.equal(responseEntry.id, requestEntry.id);
+    assert.equal(responseEntry.status, 202);
+});
+
+test('websub-unsubscribe logs an outgoing request entry and a paired response entry', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch: fakeFetch(202, ''), sessionStore });
+    const sessionId = 'websub-unsub-log-session';
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/unsubscribe`)
+        .send({ feedName: 'rss-01.xml' });
+
+    const { requestLog } = sessionStore.get(sessionId);
+    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
+
+    assert.equal(outgoing.length, 2);
+    const [responseEntry, requestEntry] = outgoing;
+    assert.equal(requestEntry.phase, 'request');
+    assert.equal(responseEntry.phase, 'response');
+    assert.equal(responseEntry.id, requestEntry.id);
+});
+
+test('websub-publish logs an outgoing request entry and a paired response entry', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch: fakeFetch(202, ''), sessionStore });
+    const sessionId = 'websub-publish-log-session';
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/publish`)
+        .send({ feedName: 'rss-01.xml' });
+
+    const { requestLog } = sessionStore.get(sessionId);
+    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
+
+    assert.equal(outgoing.length, 2);
+    const [responseEntry, requestEntry] = outgoing;
+    assert.equal(requestEntry.phase, 'request');
+    assert.equal(responseEntry.phase, 'response');
+    assert.equal(responseEntry.id, requestEntry.id);
+});

--- a/apps/client/client.test.js
+++ b/apps/client/client.test.js
@@ -48,6 +48,30 @@ test('GET /s/:id/notify does not 404 past the callback threshold while a socklog
     assert.equal(notifyRes.text, 'abc');
 });
 
+test('an outbound action refreshes the idle clock, keeping callback routes live', async() => {
+    let currentTime = 1000;
+    const sessionStore = createSessionStore({ now: () => currentTime });
+    const fetch = async() => ({ status: 200, text: async() => 'ok' });
+    const app = createApp({ sessionStore, fetch, sessionCallbackIdleMs: 500 });
+
+    await request(app).get('/s/active-session');
+
+    currentTime += 400;
+    await request(app)
+        .post('/s/active-session/actions/ping')
+        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+
+    // Past the threshold from session creation, but not from the ping above.
+    currentTime += 400;
+
+    const notifyRes = await request(app)
+        .get('/s/active-session/notify')
+        .query({ challenge: 'abc' });
+
+    assert.equal(notifyRes.status, 200);
+    assert.equal(notifyRes.text, 'abc');
+});
+
 test('a session evicted by the GC sweep is transparently recreated on the next visit', async() => {
     let currentTime = 1000;
     const sessionStore = createSessionStore({ now: () => currentTime });
@@ -375,6 +399,66 @@ test('websub-subscribe logs an outgoing request entry and a paired response entr
     assert.equal(responseEntry.phase, 'response');
     assert.equal(responseEntry.id, requestEntry.id);
     assert.equal(responseEntry.status, 202);
+});
+
+test('websub-subscribe redacts the secret in the logged request, but sends it verbatim to the hub', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 202, text: async() => '' };
+    };
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'websub-secret-session';
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/subscribe`)
+        .send({ protocol: 'websub', feedName: 'rss-01.xml', secret: 's3cr3t' });
+
+    const { requestLog } = sessionStore.get(sessionId);
+    const requestEntry = requestLog.find(
+        e => e.direction === 'outgoing' && e.phase === 'request'
+    );
+    assert.notEqual(requestEntry.body.secret, 's3cr3t');
+
+    const body = new URLSearchParams(calls[0].init.body);
+    assert.equal(body.get('hub.secret'), 's3cr3t');
+});
+
+test('a failed websub subscribe does not store the secret', async() => {
+    const fetch = async() => {
+        throw new Error('network down');
+    };
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'websub-failed-subscribe';
+
+    await request(app).get(`/s/${sessionId}`);
+    const feedUrl = `http://localhost:9000/s/${sessionId}/rss-01.xml`;
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/subscribe`)
+        .send({ protocol: 'websub', feedName: 'rss-01.xml', secret: 's3cr3t' });
+
+    assert.equal(sessionStore.get(sessionId).webSubSecrets[feedUrl], undefined);
+});
+
+test('a failed websub unsubscribe does not clear a previously stored secret', async() => {
+    const sessionStore = createSessionStore();
+    const { id: sessionId, session } = sessionStore.createSession();
+    const feedUrl = `http://localhost:9000/s/${sessionId}/rss-01.xml`;
+    session.webSubSecrets[feedUrl] = 'existing-secret';
+
+    const fetch = async() => {
+        throw new Error('network down');
+    };
+    const app = createApp({ fetch, sessionStore });
+
+    await request(app)
+        .post(`/s/${sessionId}/actions/unsubscribe`)
+        .send({ feedName: 'rss-01.xml' });
+
+    assert.equal(session.webSubSecrets[feedUrl], 'existing-secret');
 });
 
 test('websub-unsubscribe logs an outgoing request entry and a paired response entry', async() => {

--- a/apps/client/config.js
+++ b/apps/client/config.js
@@ -1,0 +1,39 @@
+const packageJson = require('./package.json');
+
+// Simple config utility that reads from process.env with defaults
+function getConfig(key, defaultValue) {
+    return process.env[key] ?? defaultValue;
+}
+
+// Parse numeric values
+function getNumericConfig(key, defaultValue) {
+    const value = process.env[key];
+    return value ? parseInt(value, 10) : defaultValue;
+}
+
+// Parse a comma-separated CIDR list, dropping blank entries.
+function getCidrListConfig(key) {
+    return String(getConfig(key, ''))
+        .split(',')
+        .map(value => value.trim())
+        .filter(Boolean);
+}
+
+module.exports = {
+    appName: 'rssCloudClient',
+    appVersion: packageJson.version,
+    domain: getConfig('DOMAIN', 'localhost'),
+    port: getNumericConfig('PORT', 9000),
+    hubServerUrl: getConfig('HUB_SERVER_URL', 'http://localhost:5337'),
+    requestTimeout: getNumericConfig('REQUEST_TIMEOUT', 4000),
+    clientFetchAllowCidrs: getCidrListConfig('CLIENT_FETCH_ALLOW_CIDRS'),
+    // 1h — past this, incoming callback/feed routes 404 for the session.
+    sessionCallbackIdleMs: getNumericConfig(
+        'SESSION_CALLBACK_IDLE_MS',
+        3600000
+    ),
+    // 24h — past this, a session is fully evicted from memory by the GC sweep.
+    sessionGcIdleMs: getNumericConfig('SESSION_GC_IDLE_MS', 86400000),
+    // 15m — how often the GC sweep runs.
+    sessionGcIntervalMs: getNumericConfig('SESSION_GC_INTERVAL_MS', 900000)
+};

--- a/apps/client/config.js
+++ b/apps/client/config.js
@@ -5,10 +5,20 @@ function getConfig(key, defaultValue) {
     return process.env[key] ?? defaultValue;
 }
 
-// Parse numeric values
+// Parse numeric values. Only the unset case falls back to defaultValue — a
+// present-but-malformed value fails loudly instead of silently becoming NaN
+// (which would otherwise break setInterval/app.listen/idle-time comparisons
+// downstream without any visible error).
 function getNumericConfig(key, defaultValue) {
     const value = process.env[key];
-    return value ? parseInt(value, 10) : defaultValue;
+    if (value === undefined) {
+        return defaultValue;
+    }
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+        throw new Error(`Invalid numeric value for ${key}: "${value}"`);
+    }
+    return parsed;
 }
 
 // Parse a comma-separated CIDR list, dropping blank entries.

--- a/apps/client/config.test.js
+++ b/apps/client/config.test.js
@@ -1,0 +1,13 @@
+// Isolated in its own file/process: config.js computes its exports at
+// require-time from process.env, so exercising a malformed value means
+// setting it before the very first require of this module.
+process.env.SESSION_GC_INTERVAL_MS = 'not-a-number';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('config.js fails loudly when a numeric env var is present but not a valid number', () => {
+    assert.throws(() => {
+        require('./config');
+    }, /SESSION_GC_INTERVAL_MS/);
+});

--- a/apps/client/index.js
+++ b/apps/client/index.js
@@ -1,0 +1,33 @@
+require('dotenv').config();
+
+const { createApp } = require('./client'),
+    { createSessionStore } = require('./lib/session-store'),
+    config = require('./config');
+
+console.log(`${config.appName} ${config.appVersion}`);
+
+const sessionStore = createSessionStore();
+const app = createApp({ sessionStore });
+
+const server = app
+    .listen(config.port, () => {
+        console.log(
+            `Listening at http://${config.domain}:${server.address().port}`
+        );
+    })
+    .on('error', error => {
+        switch (error.code) {
+        case 'EADDRINUSE':
+            console.log(`Error: Port ${config.port} is already in use.`);
+            break;
+        default:
+            console.log(error.code);
+        }
+    });
+
+app.locals.attachSessionSockets(server);
+
+const gcTimer = setInterval(() => {
+    sessionStore.sweep(config.sessionGcIdleMs);
+}, config.sessionGcIntervalMs);
+server.on('close', () => clearInterval(gcTimer));

--- a/apps/client/lib/discover.js
+++ b/apps/client/lib/discover.js
@@ -1,0 +1,68 @@
+const { Parser } = require('xml2js');
+
+// xml2js (with explicitArray: false) collapses a lone matching child to a
+// bare object but promotes two-or-more to an array — normalize once here so
+// every hub-link lookup can treat it uniformly.
+function asArray(value) {
+    if (value == null) {
+        return [];
+    }
+    return Array.isArray(value) ? value : [value];
+}
+
+// Find a rel="hub" link among a channel/feed's <atom:link>/<link> children,
+// however xml2js happened to collapse them.
+function findHubLink(links) {
+    const hub = asArray(links).find(link => link?.$?.rel === 'hub');
+    return hub ? { hubUrl: hub.$.href } : null;
+}
+
+// Detect what a feed advertises: an rssCloud <cloud> element, and/or a
+// WebSub hub link (`<atom:link rel="hub">` in RSS, `<link rel="hub">` in
+// Atom). Used by the harness's "enter a feed URL" discovery feature.
+async function parseFeedDiscovery(xmlText) {
+    let parsed;
+    try {
+        parsed = await new Parser({ explicitArray: false }).parseStringPromise(
+            xmlText
+        );
+    } catch {
+        return { rssCloud: null, webSub: null, error: 'not parseable as XML' };
+    }
+
+    const channel = parsed.rss?.channel;
+    const cloudAttrs = channel?.cloud?.$;
+    const rssCloud = cloudAttrs
+        ? {
+            domain: cloudAttrs.domain,
+            port: Number(cloudAttrs.port),
+            path: cloudAttrs.path,
+            registerProcedure: cloudAttrs.registerProcedure,
+            protocol: cloudAttrs.protocol
+        }
+        : null;
+
+    // <cloud> only ever appears under an RSS channel; a hub link can appear
+    // there (`atom:link`) or under an Atom feed root (`link`).
+    const hubLinks = channel?.['atom:link'] ?? parsed.feed?.link;
+    const webSub = findHubLink(hubLinks);
+
+    return { rssCloud, webSub };
+}
+
+// Fetch an arbitrary feed URL and report what protocols it advertises. A
+// fetch rejection (network error, SSRF block) propagates to the caller; a
+// non-2xx response or unparseable body is reported via `.error` instead.
+async function discoverFeed({ url, fetch = globalThis.fetch }) {
+    const res = await fetch(url);
+    if (res.status < 200 || res.status >= 300) {
+        return {
+            rssCloud: null,
+            webSub: null,
+            error: `fetch failed: ${res.status}`
+        };
+    }
+    return parseFeedDiscovery(await res.text());
+}
+
+module.exports = { parseFeedDiscovery, discoverFeed };

--- a/apps/client/lib/discover.js
+++ b/apps/client/lib/discover.js
@@ -43,7 +43,10 @@ async function parseFeedDiscovery(xmlText) {
         : null;
 
     // <cloud> only ever appears under an RSS channel; a hub link can appear
-    // there (`atom:link`) or under an Atom feed root (`link`).
+    // there (`atom:link`) or under an Atom feed root (`link`). This assumes
+    // the RSS document uses the conventional `atom:` namespace prefix (as
+    // every real-world generator does) — a feed that binds the Atom
+    // namespace to a different alias would go undetected here.
     const hubLinks = channel?.['atom:link'] ?? parsed.feed?.link;
     const webSub = findHubLink(hubLinks);
 

--- a/apps/client/lib/discover.test.js
+++ b/apps/client/lib/discover.test.js
@@ -1,0 +1,123 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { renderCloudFeed } = require('./feed');
+const { parseFeedDiscovery, discoverFeed } = require('./discover');
+
+const CLOUD = {
+    domain: 'localhost',
+    port: 5337,
+    path: '/RPC2',
+    registerProcedure: 'rssCloud.pleaseNotify',
+    protocol: 'xml-rpc'
+};
+
+function sampleFeed(opts = {}) {
+    return renderCloudFeed({
+        title: 'Test Feed',
+        link: 'http://sub.example:9000/rss-01.xml',
+        description: 'Test feed for rssCloud',
+        cloud: CLOUD,
+        items: [
+            {
+                title: 'Update one',
+                description: 'first',
+                pubDate: new Date('2026-01-02T03:04:05Z'),
+                guid: 'rss-01-0'
+            }
+        ],
+        ...opts
+    });
+}
+
+test('detects the <cloud> element rendered by renderCloudFeed', async() => {
+    const xml = sampleFeed();
+
+    const result = await parseFeedDiscovery(xml);
+
+    assert.deepEqual(result.rssCloud, CLOUD);
+    assert.equal(result.webSub, null);
+});
+
+test('detects both <cloud> and an atom:link rel=hub when a feed advertises both', async() => {
+    const xml = sampleFeed({ hub: 'http://localhost:5337/websub' });
+
+    const result = await parseFeedDiscovery(xml);
+
+    assert.deepEqual(result.rssCloud, CLOUD);
+    assert.deepEqual(result.webSub, { hubUrl: 'http://localhost:5337/websub' });
+});
+
+const ATOM_FEED = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>Atom Test Feed</title>
+    <link rel="self" href="http://sub.example:9000/atom.xml" />
+    <link rel="hub" href="http://hub.example/websub" />
+    <entry>
+        <title>Entry one</title>
+        <id>urn:uuid:1</id>
+    </entry>
+</feed>`;
+
+test('detects a WebSub hub link in an Atom feed with no <cloud> element', async() => {
+    const result = await parseFeedDiscovery(ATOM_FEED);
+
+    assert.equal(result.rssCloud, null);
+    assert.deepEqual(result.webSub, { hubUrl: 'http://hub.example/websub' });
+});
+
+const PLAIN_RSS_FEED = `<?xml version="1.0"?>
+<rss version="2.0">
+    <channel>
+        <title>Plain Feed</title>
+        <link>http://sub.example:9000/plain.xml</link>
+        <description>No cloud, no hub</description>
+        <item><title>Entry one</title><guid>g0</guid></item>
+    </channel>
+</rss>`;
+
+test('reports null for both when a feed advertises neither protocol', async() => {
+    const result = await parseFeedDiscovery(PLAIN_RSS_FEED);
+
+    assert.equal(result.rssCloud, null);
+    assert.equal(result.webSub, null);
+});
+
+test('reports an error instead of throwing when the body is not parseable XML', async() => {
+    const result = await parseFeedDiscovery('<not>xml<');
+
+    assert.equal(result.rssCloud, null);
+    assert.equal(result.webSub, null);
+    assert.equal(result.error, 'not parseable as XML');
+});
+
+test('discoverFeed propagates a fetch rejection (e.g. an SSRF block) to the caller', async() => {
+    const fetch = async() => {
+        throw new Error('blocked');
+    };
+
+    await assert.rejects(
+        () => discoverFeed({ url: 'http://blocked.example/rss', fetch }),
+        /blocked/
+    );
+});
+
+test('discoverFeed short-circuits on a non-2xx response without parsing the body', async() => {
+    let textCalled = false;
+    const fetch = async() => ({
+        status: 404,
+        text: async() => {
+            textCalled = true;
+            return 'Not Found';
+        }
+    });
+
+    const result = await discoverFeed({
+        url: 'http://sub.example/missing.xml',
+        fetch
+    });
+
+    assert.equal(result.rssCloud, null);
+    assert.equal(result.webSub, null);
+    assert.equal(result.error, 'fetch failed: 404');
+    assert.equal(textCalled, false);
+});

--- a/apps/client/lib/guarded-fetch.js
+++ b/apps/client/lib/guarded-fetch.js
@@ -1,0 +1,15 @@
+const { createSafeFetch, createCidrAllowList } = require('@rsscloud/core');
+
+// SSRF-guarded fetch for the harness's own outbound calls (feed discovery,
+// pleaseNotify/ping, WebSub hub.*): refuses loopback/private/link-local
+// targets by default, with an allowlist escape hatch for local dev — the
+// same tension apps/server's guardedFetchOption already solves.
+function createGuardedFetch({ allowCidrs = [], timeoutMs } = {}) {
+    const options = { timeoutMs };
+    if (allowCidrs.length > 0) {
+        options.allow = createCidrAllowList(allowCidrs);
+    }
+    return createSafeFetch(options);
+}
+
+module.exports = { createGuardedFetch };

--- a/apps/client/lib/guarded-fetch.test.js
+++ b/apps/client/lib/guarded-fetch.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { SsrfBlockedError } = require('@rsscloud/core');
+const { createGuardedFetch } = require('./guarded-fetch');
+
+function withLoopbackServer(handler) {
+    return new Promise((resolve, reject) => {
+        const server = http.createServer(handler);
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+}
+
+test('rejects a loopback target by default', async() => {
+    const fetch = createGuardedFetch({});
+
+    await assert.rejects(() => fetch('http://127.0.0.1:8080/'), err => {
+        assert.ok(err.cause instanceof SsrfBlockedError);
+        return true;
+    });
+});
+
+test('reaches a loopback target when its CIDR is allow-listed', async() => {
+    const server = await withLoopbackServer((req, res) => res.end('ok'));
+    const { port } = server.address();
+
+    try {
+        const fetch = createGuardedFetch({ allowCidrs: ['127.0.0.0/8'] });
+        const res = await fetch(`http://127.0.0.1:${port}/`);
+
+        assert.equal(res.status, 200);
+        assert.equal(await res.text(), 'ok');
+    } finally {
+        server.close();
+    }
+});

--- a/apps/client/lib/index.js
+++ b/apps/client/lib/index.js
@@ -2,11 +2,14 @@ const { createRssCloudClient } = require('./client');
 const { renderCloudFeed } = require('./feed');
 const { buildNotifyResponse } = require('./notify');
 const { createWebSubClient, readVerification } = require('./websub');
+const { discoverFeed, parseFeedDiscovery } = require('./discover');
 
 module.exports = {
     createRssCloudClient,
     renderCloudFeed,
     buildNotifyResponse,
     createWebSubClient,
-    readVerification
+    readVerification,
+    discoverFeed,
+    parseFeedDiscovery
 };

--- a/apps/client/lib/session-store.js
+++ b/apps/client/lib/session-store.js
@@ -1,6 +1,11 @@
 const { randomUUID } = require('crypto');
 
 const MAX_LOG_ENTRIES = 100;
+// Absolute ceiling on how long a live socket alone can keep a session
+// exempt from idle/GC checks — long enough to cover "left a tab open over a
+// long weekend," but a hard backstop against an indefinitely-held
+// connection pinning a session in memory forever on a public deployment.
+const MAX_SESSION_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 // Per-session in-memory state for the client harness: request log, served
 // feed items, and WebSub secrets, isolated per session id so concurrent
@@ -45,16 +50,24 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
         }
     }
 
+    // A live socklog viewer is itself a sign of active use — e.g. someone
+    // left a tab open overnight watching an external feed — but only up to
+    // MAX_SESSION_AGE_MS; past that, a held-open connection stops overriding
+    // the idle/GC checks and falls back to the normal lastOutgoingAt rules
+    // below, same as a session with no socket at all.
+    function hasExemptSocket(session) {
+        return (
+            session.sockets.size > 0 &&
+            now() - session.createdAt <= MAX_SESSION_AGE_MS
+        );
+    }
+
     function isIdle(id, idleMs) {
         const session = sessions.get(id);
         if (!session) {
             return true;
         }
-        // A live socklog viewer is itself a sign of active use — e.g.
-        // someone left a tab open overnight watching an external feed. Don't
-        // let the callback surface go dark just because no button's been
-        // clicked recently.
-        if (session.sockets.size > 0) {
+        if (hasExemptSocket(session)) {
             return false;
         }
         return now() - session.lastOutgoingAt > idleMs;
@@ -63,10 +76,13 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
     function sweep(maxIdleMs) {
         let evicted = 0;
         for (const [id, session] of sessions) {
-            if (session.sockets.size > 0) {
+            if (hasExemptSocket(session)) {
                 continue;
             }
             if (now() - session.lastOutgoingAt > maxIdleMs) {
+                for (const socket of session.sockets) {
+                    socket.terminate?.();
+                }
                 sessions.delete(id);
                 evicted += 1;
             }

--- a/apps/client/lib/session-store.js
+++ b/apps/client/lib/session-store.js
@@ -1,0 +1,90 @@
+const { randomUUID } = require('crypto');
+
+// Per-session in-memory state for the client harness: request log, served
+// feed items, and WebSub secrets, isolated per session id so concurrent
+// public users don't see each other's traffic.
+function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID } = {}) {
+    const sessions = new Map();
+
+    function newSession() {
+        const createdAt = now();
+        return {
+            requestLog: [],
+            feedItems: {},
+            webSubSecrets: {},
+            sockets: new Set(),
+            createdAt,
+            lastOutgoingAt: createdAt
+        };
+    }
+
+    function createSession() {
+        const id = idGenerator();
+        const session = newSession();
+        sessions.set(id, session);
+        return { id, session };
+    }
+
+    function get(id) {
+        return sessions.get(id);
+    }
+
+    function getOrCreate(id) {
+        if (!sessions.has(id)) {
+            sessions.set(id, newSession());
+        }
+        return sessions.get(id);
+    }
+
+    function touchOutgoing(id) {
+        const session = sessions.get(id);
+        if (session) {
+            session.lastOutgoingAt = now();
+        }
+    }
+
+    function isIdle(id, idleMs) {
+        const session = sessions.get(id);
+        if (!session) {
+            return true;
+        }
+        // A live socklog viewer is itself a sign of active use — e.g.
+        // someone left a tab open overnight watching an external feed. Don't
+        // let the callback surface go dark just because no button's been
+        // clicked recently.
+        if (session.sockets.size > 0) {
+            return false;
+        }
+        return now() - session.lastOutgoingAt > idleMs;
+    }
+
+    function sweep(maxIdleMs) {
+        let evicted = 0;
+        for (const [id, session] of sessions) {
+            if (session.sockets.size > 0) {
+                continue;
+            }
+            if (now() - session.lastOutgoingAt > maxIdleMs) {
+                sessions.delete(id);
+                evicted += 1;
+            }
+        }
+        return evicted;
+    }
+
+    function size() {
+        return sessions.size;
+    }
+
+    return {
+        createSession,
+        get,
+        getOrCreate,
+        touchOutgoing,
+        isIdle,
+        sweep,
+        size
+    };
+}
+
+module.exports = { createSessionStore };

--- a/apps/client/lib/session-store.js
+++ b/apps/client/lib/session-store.js
@@ -1,5 +1,7 @@
 const { randomUUID } = require('crypto');
 
+const MAX_LOG_ENTRIES = 100;
+
 // Per-session in-memory state for the client harness: request log, served
 // feed items, and WebSub secrets, isolated per session id so concurrent
 // public users don't see each other's traffic.
@@ -76,6 +78,20 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
         return sessions.size;
     }
 
+    // Owns the request log's lifecycle (append + cap) so callers (the
+    // WebSocket layer, the incoming-request middleware) don't each
+    // reimplement the truncation policy.
+    function appendLog(id, entry) {
+        const session = sessions.get(id);
+        if (!session) {
+            return;
+        }
+        session.requestLog.unshift(entry);
+        if (session.requestLog.length > MAX_LOG_ENTRIES) {
+            session.requestLog.pop();
+        }
+    }
+
     return {
         createSession,
         get,
@@ -83,7 +99,8 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
         touchOutgoing,
         isIdle,
         sweep,
-        size
+        size,
+        appendLog
     };
 }
 

--- a/apps/client/lib/session-store.test.js
+++ b/apps/client/lib/session-store.test.js
@@ -111,6 +111,35 @@ test('sweep does not evict a session that has a live socket, however long since 
     assert.equal(store.get(id), session);
 });
 
+test('appendLog unshifts an entry into the session\'s requestLog, newest-first', () => {
+    const store = createSessionStore({ now: () => 1000 });
+    const { id, session } = store.createSession();
+
+    store.appendLog(id, { id: '1' });
+    store.appendLog(id, { id: '2' });
+
+    assert.deepEqual(session.requestLog, [{ id: '2' }, { id: '1' }]);
+});
+
+test('appendLog is a safe no-op for an unknown id', () => {
+    const store = createSessionStore({ now: () => 1000 });
+
+    assert.doesNotThrow(() => store.appendLog('unknown-id', { id: '1' }));
+});
+
+test('appendLog caps the requestLog at 100 entries, dropping the oldest', () => {
+    const store = createSessionStore({ now: () => 1000 });
+    const { id, session } = store.createSession();
+
+    for (let i = 0; i < 101; i++) {
+        store.appendLog(id, { id: String(i) });
+    }
+
+    assert.equal(session.requestLog.length, 100);
+    assert.equal(session.requestLog[0].id, '100');
+    assert.equal(session.requestLog[99].id, '1');
+});
+
 test('size reflects the number of live sessions, including after a sweep', () => {
     let currentTime = 1000;
     const store = createSessionStore({ now: () => currentTime });

--- a/apps/client/lib/session-store.test.js
+++ b/apps/client/lib/session-store.test.js
@@ -1,0 +1,131 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createSessionStore } = require('./session-store');
+
+test('createSession mints a fresh session with the expected shape', () => {
+    const store = createSessionStore({ now: () => 1000 });
+
+    const { id, session } = store.createSession();
+
+    assert.equal(typeof id, 'string');
+    assert.ok(id.length > 0);
+    assert.deepEqual(session.requestLog, []);
+    assert.deepEqual(session.feedItems, {});
+    assert.deepEqual(session.webSubSecrets, {});
+    assert.equal(session.sockets.size, 0);
+    assert.equal(session.createdAt, 1000);
+    assert.equal(session.lastOutgoingAt, 1000);
+});
+
+test('get returns the session created under an id, or undefined for an unknown id', () => {
+    const store = createSessionStore({ now: () => 1000 });
+    const { id, session } = store.createSession();
+
+    assert.equal(store.get(id), session);
+    assert.equal(store.get('unknown-id'), undefined);
+});
+
+test('getOrCreate creates a session under an unknown id, then returns the same session on repeat calls', () => {
+    const store = createSessionStore({ now: () => 1000 });
+
+    const first = store.getOrCreate('bookmarked-id');
+    const second = store.getOrCreate('bookmarked-id');
+
+    assert.equal(first, second);
+    assert.equal(store.get('bookmarked-id'), first);
+});
+
+test('touchOutgoing updates lastOutgoingAt to the current time', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+    const { id, session } = store.createSession();
+
+    currentTime = 5000;
+    store.touchOutgoing(id);
+
+    assert.equal(session.lastOutgoingAt, 5000);
+});
+
+test('touchOutgoing is a safe no-op for an unknown id', () => {
+    const store = createSessionStore({ now: () => 1000 });
+
+    assert.doesNotThrow(() => store.touchOutgoing('unknown-id'));
+});
+
+test('isIdle is true for an unknown id', () => {
+    const store = createSessionStore({ now: () => 1000 });
+
+    assert.equal(store.isIdle('unknown-id', 500), true);
+});
+
+test('isIdle boundary: exactly at the threshold is not idle, one past it is', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+    const { id } = store.createSession();
+
+    currentTime = 1000 + 500;
+    assert.equal(store.isIdle(id, 500), false);
+
+    currentTime = 1000 + 501;
+    assert.equal(store.isIdle(id, 500), true);
+});
+
+test('isIdle is false while the session has a live socket, however long since lastOutgoingAt', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+    const { id, session } = store.createSession();
+    session.sockets.add({});
+
+    currentTime = 1000 + 501;
+
+    assert.equal(store.isIdle(id, 500), false);
+});
+
+test('sweep evicts only sessions idle beyond the threshold', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+
+    const stale = store.createSession();
+
+    currentTime = 1000 + 500;
+    const fresh = store.createSession();
+
+    currentTime = 1000 + 501;
+    const evicted = store.sweep(500);
+
+    assert.equal(evicted, 1);
+    assert.equal(store.get(stale.id), undefined);
+    assert.equal(store.get(fresh.id), fresh.session);
+});
+
+test('sweep does not evict a session that has a live socket, however long since lastOutgoingAt', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+    const { id, session } = store.createSession();
+    session.sockets.add({});
+
+    currentTime = 1000 + 501;
+    const evicted = store.sweep(500);
+
+    assert.equal(evicted, 0);
+    assert.equal(store.get(id), session);
+});
+
+test('size reflects the number of live sessions, including after a sweep', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+
+    assert.equal(store.size(), 0);
+
+    const stale = store.createSession();
+    currentTime = 1000 + 500;
+    store.createSession();
+
+    assert.equal(store.size(), 2);
+
+    currentTime = 1000 + 501;
+    store.sweep(500);
+
+    assert.equal(store.size(), 1);
+    assert.equal(store.get(stale.id), undefined);
+});

--- a/apps/client/lib/session-store.test.js
+++ b/apps/client/lib/session-store.test.js
@@ -111,6 +111,46 @@ test('sweep does not evict a session that has a live socket, however long since 
     assert.equal(store.get(id), session);
 });
 
+const EIGHT_DAYS_MS = 8 * 24 * 60 * 60 * 1000;
+
+test('isIdle stops exempting a live-socket session once it exceeds the absolute max session age', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+    const { id, session } = store.createSession();
+    session.sockets.add({});
+
+    currentTime = 1000 + EIGHT_DAYS_MS;
+
+    assert.equal(store.isIdle(id, 500), true);
+});
+
+test('isIdle still returns false past the absolute max session age given recent outgoing activity', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+    const { id, session } = store.createSession();
+    session.sockets.add({});
+
+    currentTime = 1000 + EIGHT_DAYS_MS;
+    store.touchOutgoing(id);
+
+    assert.equal(store.isIdle(id, 500), false);
+});
+
+test('sweep evicts a long-lived socket-holding session once it exceeds the absolute max session age, terminating its socket', () => {
+    let currentTime = 1000;
+    const store = createSessionStore({ now: () => currentTime });
+    const { id, session } = store.createSession();
+    let terminated = false;
+    session.sockets.add({ terminate: () => { terminated = true; } });
+
+    currentTime = 1000 + EIGHT_DAYS_MS;
+    const evicted = store.sweep(500);
+
+    assert.equal(evicted, 1);
+    assert.equal(store.get(id), undefined);
+    assert.equal(terminated, true);
+});
+
 test('appendLog unshifts an entry into the session\'s requestLog, newest-first', () => {
     const store = createSessionStore({ now: () => 1000 });
     const { id, session } = store.createSession();

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -2,12 +2,12 @@
     "name": "@rsscloud/client-app",
     "version": "0.0.0",
     "private": true,
-    "description": "Interactive dev harness for the rssCloud client (Subscribe/Ping UI + request log)",
-    "main": "client.js",
+    "description": "Interactive rssCloud/WebSub test harness (unified subscribe/publish UI, feed discovery, live traffic log, session-isolated for public deployment)",
+    "main": "index.js",
     "scripts": {
-        "start": "node --use_strict client.js",
-        "dev": "nodemon --use_strict client.js",
-        "test": "node --test lib/*.test.js",
+        "start": "node --use_strict index.js",
+        "dev": "nodemon --use_strict index.js",
+        "test": "node --test lib/*.test.js *.test.js",
         "lint": "eslint --fix *.js lib/"
     },
     "engines": {
@@ -16,15 +16,19 @@
     "author": "Andrew Shell <andrew@andrewshell.org>",
     "license": "MIT",
     "dependencies": {
+        "@rsscloud/core": "workspace:*",
         "@rsscloud/xml-rpc": "workspace:*",
         "body-parser": "^2.2.2",
+        "dotenv": "^17.4.2",
         "express": "^4.22.2",
         "morgan": "^1.10.1",
+        "ws": "^8.21.0",
         "xml2js": "^0.6.2"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
         "eslint": "^10.4.0",
-        "nodemon": "3.1.14"
+        "nodemon": "3.1.14",
+        "supertest": "^7.2.2"
     }
 }

--- a/apps/client/public/app.js
+++ b/apps/client/public/app.js
@@ -1,0 +1,133 @@
+// Client-side wiring for the unified control box. No <form> submission
+// anywhere — every action is a button click that fetch()es a JSON action
+// endpoint; the outcome shows up as log entries in the live socklog viewer
+// instead of navigating to a result page.
+
+const sessionId = document.body.dataset.sessionId;
+
+const protocolSelect = document.getElementById('protocol');
+const feedUrlInput = document.getElementById('feedUrl');
+const feedNameInput = document.getElementById('feedName');
+const serverOverrideInput = document.getElementById('serverOverride');
+const leaseSecondsInput = document.getElementById('leaseSeconds');
+const secretInput = document.getElementById('secret');
+const pingButton = document.getElementById('pingButton');
+const publishButton = document.getElementById('publishButton');
+
+// The most recent successful discovery, so switching the protocol dropdown
+// can re-populate the override field without a second round trip.
+let lastDiscovery = null;
+
+async function postAction(action, fields) {
+    const res = await fetch(`/s/${sessionId}/actions/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(fields)
+    });
+    return res.json();
+}
+
+// Show only the controls relevant to the selected protocol. Never
+// hard-disables the others — forcing an undetected/unselected protocol is a
+// deliberate testing feature, not a bug.
+function updateProtocolVisibility() {
+    const isWebSub = protocolSelect.value === 'websub';
+    document.querySelectorAll('.websub-only').forEach(el => {
+        el.hidden = !isWebSub;
+    });
+    document.querySelectorAll('.rsscloud-only').forEach(el => {
+        el.hidden = isWebSub;
+    });
+    applyDiscoveryToOverride();
+}
+
+// Populate the override field from the last discovery, interpreted for
+// whichever protocol is currently selected.
+function applyDiscoveryToOverride() {
+    if (!lastDiscovery) {
+        return;
+    }
+    if (protocolSelect.value === 'websub' && lastDiscovery.webSub) {
+        serverOverrideInput.value = lastDiscovery.webSub.hubUrl;
+    } else if (protocolSelect.value !== 'websub' && lastDiscovery.rssCloud) {
+        const { domain, port } = lastDiscovery.rssCloud;
+        serverOverrideInput.value = `http://${domain}:${port}`;
+    }
+}
+
+// Subscriber mode: an external feed URL means we're testing someone else's
+// feed, so we must never fake-publish or ping it. This mirrors the
+// server-side enforcement (the ping/publish actions only ever accept a
+// feedName, never a feedUrl) at the UI layer.
+function updateSubscriberMode() {
+    const isExternal = feedUrlInput.value.trim() !== '';
+    pingButton.disabled = isExternal;
+    publishButton.disabled = isExternal;
+}
+
+function currentFeedTarget() {
+    const feedUrl = feedUrlInput.value.trim();
+    return feedUrl ? { feedUrl } : { feedName: feedNameInput.value.trim() };
+}
+
+function currentServerOverride() {
+    const value = serverOverrideInput.value.trim();
+    return value ? { server: value } : {};
+}
+
+protocolSelect.addEventListener('change', updateProtocolVisibility);
+feedUrlInput.addEventListener('input', updateSubscriberMode);
+
+document.getElementById('discoverButton').addEventListener('click', async() => {
+    const feedUrl = feedUrlInput.value.trim();
+    if (!feedUrl) {
+        return;
+    }
+    const result = await postAction('discover', { feedUrl });
+    lastDiscovery = result;
+    if (result.rssCloud && result.rssCloud.protocol === 'xml-rpc') {
+        protocolSelect.value = 'rsscloud-xml-rpc';
+    } else if (result.rssCloud) {
+        protocolSelect.value = 'rsscloud-rest';
+    } else if (result.webSub) {
+        protocolSelect.value = 'websub';
+    }
+    updateProtocolVisibility();
+});
+
+document.getElementById('subscribeButton').addEventListener('click', () => {
+    postAction('subscribe', {
+        protocol: protocolSelect.value,
+        leaseSeconds: leaseSecondsInput.value
+            ? parseInt(leaseSecondsInput.value, 10)
+            : undefined,
+        secret: secretInput.value || undefined,
+        ...currentFeedTarget(),
+        ...currentServerOverride()
+    });
+});
+
+document.getElementById('unsubscribeButton').addEventListener('click', () => {
+    postAction('unsubscribe', {
+        ...currentFeedTarget(),
+        ...currentServerOverride()
+    });
+});
+
+pingButton.addEventListener('click', () => {
+    postAction('ping', {
+        protocol: protocolSelect.value,
+        feedName: feedNameInput.value.trim(),
+        ...currentServerOverride()
+    });
+});
+
+publishButton.addEventListener('click', () => {
+    postAction('publish', {
+        feedName: feedNameInput.value.trim(),
+        ...currentServerOverride()
+    });
+});
+
+updateProtocolVisibility();
+updateSubscriberMode();

--- a/apps/client/public/app.js
+++ b/apps/client/public/app.js
@@ -18,13 +18,23 @@ const publishButton = document.getElementById('publishButton');
 // can re-populate the override field without a second round trip.
 let lastDiscovery = null;
 
+// Never rejects — a network failure (can't reach the server at all) or a
+// non-JSON response (e.g. a proxy's error page) never reaches the server-side
+// broadcast that would otherwise show it in the traffic log, so this is the
+// one place that needs its own user-visible failure path.
 async function postAction(action, fields) {
-    const res = await fetch(`/s/${sessionId}/actions/${action}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(fields)
-    });
-    return res.json();
+    try {
+        const res = await fetch(`/s/${sessionId}/actions/${action}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(fields)
+        });
+        return await res.json();
+    } catch (error) {
+        console.error(`${action} failed:`, error);
+        alert(`${action} failed: ${error.message}`);
+        return { error: error.message };
+    }
 }
 
 // Show only the controls relevant to the selected protocol. Never

--- a/apps/client/public/css/style.css
+++ b/apps/client/public/css/style.css
@@ -1,0 +1,261 @@
+/* Simple, clean styles for rssCloud Server */
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+        Arial, sans-serif;
+    line-height: 1.6;
+    color: #333;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #fff;
+}
+
+h1 {
+    color: #2c3e50;
+    border-bottom: 3px solid #3498db;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+}
+
+h2 {
+    color: #34495e;
+    margin-top: 30px;
+}
+
+p {
+    margin-bottom: 15px;
+}
+
+/* Navigation and links */
+ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+li {
+    margin-bottom: 10px;
+}
+
+a {
+    color: #3498db;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Forms */
+form {
+    background: #f8f9fa;
+    padding: 20px;
+    border-radius: 5px;
+    margin: 20px 0;
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+
+input[type='text'] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-bottom: 15px;
+    font-size: 16px;
+}
+
+button {
+    background-color: #3498db;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+button:hover {
+    background-color: #2980b9;
+}
+
+/* Tables */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+    background: white;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+th,
+td {
+    padding: 12px;
+    text-align: left;
+    border-bottom: 1px solid #ddd;
+}
+
+th {
+    background-color: #f8f9fa;
+    font-weight: bold;
+    color: #2c3e50;
+}
+
+tr:hover {
+    background-color: #f5f5f5;
+}
+
+/* Stats-specific styles */
+.stats-table td:last-child,
+.stats-table th:last-child {
+    width: 120px;
+    text-align: right;
+}
+
+.stats-table .toggle-row td {
+    background-color: #f8f9fa;
+    text-align: center;
+    width: auto;
+    border-bottom: none;
+    padding: 10px 12px;
+}
+
+.stats-table .toggle-row:hover {
+    background-color: #f8f9fa;
+}
+
+.stats-table .toggle-row a {
+    color: #2c3e50;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.stats-table .toggle-row a:hover {
+    text-decoration: underline;
+}
+
+.stats-table .feed-last-update {
+    color: #777;
+    font-size: 0.85em;
+}
+
+/* Log-specific styles */
+.log-table {
+    font-size: 14px;
+}
+
+.log-table th {
+    position: sticky;
+    top: 0;
+    background-color: #2c3e50;
+    color: white;
+}
+
+.log-table td:first-child {
+    font-weight: bold;
+    color: #e74c3c;
+}
+
+.log-table .time-column {
+    white-space: nowrap;
+    font-family:
+        'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+        'Courier New', monospace;
+}
+
+.log-table .secs-column {
+    text-align: right;
+    font-family:
+        'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+        'Courier New', monospace;
+}
+
+/* Headers display */
+.headers {
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    padding: 10px;
+    margin: 10px 0;
+    font-family:
+        'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+        'Courier New', monospace;
+    font-size: 12px;
+}
+
+.headers h4 {
+    margin: 0 0 10px 0;
+    color: #495057;
+    font-family: inherit;
+}
+
+.headers ul {
+    margin: 0;
+    padding-left: 20px;
+    list-style-type: disc;
+}
+
+.headers li {
+    margin-bottom: 5px;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    body {
+        padding: 10px;
+    }
+
+    table {
+        font-size: 12px;
+    }
+
+    th,
+    td {
+        padding: 8px 4px;
+    }
+
+    .log-table .secs-column,
+    .log-table .time-column {
+        display: none;
+    }
+}
+
+/* Utility classes */
+.text-center {
+    text-align: center;
+}
+
+.mt-20 {
+    margin-top: 20px;
+}
+
+.mb-20 {
+    margin-bottom: 20px;
+}
+
+.log-panel {
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.feed-url {
+    margin-top: 4px;
+    margin-bottom: 0;
+    font-size: 1em;
+    color: #999;
+}
+
+.feed-url code {
+    font-size: 1em;
+    color: #888;
+}

--- a/apps/client/session-sockets.js
+++ b/apps/client/session-sockets.js
@@ -1,0 +1,61 @@
+const { WebSocketServer } = require('ws');
+const { URL } = require('url');
+
+const MAX_LOG_ENTRIES = 100;
+const LOGS_PATH = /^\/s\/([^/]+)\/logs$/;
+
+// Per-session socklog WebSocket feed. `attach(server)` wires the upgrade
+// handling once the real http.Server exists (after `.listen()`); `broadcast`
+// only needs the session store, so route handlers can use it immediately.
+function createSessionSockets({ sessionStore }) {
+    const wss = new WebSocketServer({ noServer: true });
+
+    function attach(server) {
+        server.on('upgrade', (request, socket, head) => {
+            const pathname = new URL(
+                request.url,
+                `http://${request.headers.host}`
+            ).pathname;
+            const match = LOGS_PATH.exec(pathname);
+            const session = match && sessionStore.get(match[1]);
+
+            if (!session) {
+                socket.destroy();
+                return;
+            }
+
+            wss.handleUpgrade(request, socket, head, ws => {
+                session.sockets.add(ws);
+                // Backfill a late-connecting viewer with this session's
+                // history, oldest-first (requestLog itself is newest-first).
+                for (const entry of session.requestLog.slice().reverse()) {
+                    ws.send(JSON.stringify(entry));
+                }
+                ws.on('close', () => session.sockets.delete(ws));
+            });
+        });
+    }
+
+    function broadcast(sessionId, entry) {
+        const session = sessionStore.get(sessionId);
+        if (!session) {
+            return;
+        }
+
+        session.requestLog.unshift(entry);
+        if (session.requestLog.length > MAX_LOG_ENTRIES) {
+            session.requestLog.pop();
+        }
+
+        const message = JSON.stringify(entry);
+        for (const ws of session.sockets) {
+            if (ws.readyState === ws.OPEN) {
+                ws.send(message);
+            }
+        }
+    }
+
+    return { attach, broadcast };
+}
+
+module.exports = { createSessionSockets };

--- a/apps/client/session-sockets.js
+++ b/apps/client/session-sockets.js
@@ -1,7 +1,6 @@
 const { WebSocketServer } = require('ws');
 const { URL } = require('url');
 
-const MAX_LOG_ENTRIES = 100;
 const LOGS_PATH = /^\/s\/([^/]+)\/logs$/;
 
 // Per-session socklog WebSocket feed. `attach(server)` wires the upgrade
@@ -42,10 +41,7 @@ function createSessionSockets({ sessionStore }) {
             return;
         }
 
-        session.requestLog.unshift(entry);
-        if (session.requestLog.length > MAX_LOG_ENTRIES) {
-            session.requestLog.pop();
-        }
+        sessionStore.appendLog(sessionId, entry);
 
         const message = JSON.stringify(entry);
         for (const ws of session.sockets) {

--- a/apps/client/session-sockets.test.js
+++ b/apps/client/session-sockets.test.js
@@ -1,0 +1,160 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const WebSocket = require('ws');
+const { createSessionStore } = require('./lib/session-store');
+const { createSessionSockets } = require('./session-sockets');
+
+function listen(server) {
+    return new Promise(resolve => {
+        server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+    });
+}
+
+function waitForOpen(ws) {
+    return new Promise((resolve, reject) => {
+        ws.once('open', resolve);
+        ws.once('error', reject);
+    });
+}
+
+function waitForMessage(ws) {
+    return new Promise(resolve => {
+        ws.once('message', data => resolve(JSON.parse(data.toString())));
+    });
+}
+
+test('broadcast delivers a JSON message to a socket connected on a known session', async() => {
+    const sessionStore = createSessionStore();
+    const { id: sessionId } = sessionStore.createSession();
+    const { attach, broadcast } = createSessionSockets({ sessionStore });
+    const server = http.createServer();
+    attach(server);
+    const port = await listen(server);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/s/${sessionId}/logs`);
+    await waitForOpen(ws);
+    const received = waitForMessage(ws);
+
+    broadcast(sessionId, { id: '1', direction: 'incoming', method: 'GET' });
+
+    assert.deepEqual(await received, {
+        id: '1',
+        direction: 'incoming',
+        method: 'GET'
+    });
+
+    ws.close();
+    server.close();
+});
+
+test('a connection for an unknown session id is refused', async() => {
+    const sessionStore = createSessionStore();
+    const { attach } = createSessionSockets({ sessionStore });
+    const server = http.createServer();
+    attach(server);
+    const port = await listen(server);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/s/unknown-id/logs`);
+    const outcome = await new Promise(resolve => {
+        ws.once('error', () => resolve('refused'));
+        ws.once('open', () => resolve('opened'));
+    });
+
+    assert.equal(outcome, 'refused');
+
+    server.close();
+});
+
+function waitForClose(ws) {
+    return new Promise(resolve => ws.once('close', resolve));
+}
+
+async function waitUntil(predicate, timeoutMs = 2000) {
+    const start = Date.now();
+    while (!predicate()) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error('waitUntil timed out');
+        }
+        await new Promise(resolve => setTimeout(resolve, 5));
+    }
+}
+
+test('a closed socket is removed from the session\'s socket set', async() => {
+    const sessionStore = createSessionStore();
+    const { id: sessionId, session } = sessionStore.createSession();
+    const { attach } = createSessionSockets({ sessionStore });
+    const server = http.createServer();
+    attach(server);
+    const port = await listen(server);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/s/${sessionId}/logs`);
+    await waitForOpen(ws);
+    assert.equal(session.sockets.size, 1);
+
+    ws.close();
+    await waitForClose(ws);
+    // The server-side 'close' handler fires from the same close handshake,
+    // but not necessarily by the time the client's own 'close' event does.
+    await waitUntil(() => session.sockets.size === 0);
+
+    assert.equal(session.sockets.size, 0);
+
+    server.close();
+});
+
+test('sweeping does not evict or close a session with a live socket connection', async() => {
+    let currentTime = 1000;
+    const sessionStore = createSessionStore({ now: () => currentTime });
+    const { id: sessionId } = sessionStore.createSession();
+    const { attach } = createSessionSockets({ sessionStore });
+    const server = http.createServer();
+    attach(server);
+    const port = await listen(server);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/s/${sessionId}/logs`);
+    await waitForOpen(ws);
+    let closed = false;
+    ws.once('close', () => { closed = true; });
+
+    // Someone leaving a tab open overnight watching an external feed: no
+    // outgoing action for way past the GC threshold, but the socket is
+    // still connected — sweeping must leave both the session and the
+    // connection alone.
+    currentTime = 1000 + 86400001;
+    const evicted = sessionStore.sweep(86400000);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert.equal(evicted, 0);
+    assert.equal(closed, false);
+    assert.ok(sessionStore.get(sessionId));
+
+    ws.close();
+    server.close();
+});
+
+test('connecting replays buffered history oldest-first before any new broadcast', async() => {
+    const sessionStore = createSessionStore();
+    const { id: sessionId, session } = sessionStore.createSession();
+    // requestLog is maintained newest-first (unshift), as today.
+    session.requestLog = [
+        { id: '2', method: 'POST' },
+        { id: '1', method: 'GET' }
+    ];
+    const { attach } = createSessionSockets({ sessionStore });
+    const server = http.createServer();
+    attach(server);
+    const port = await listen(server);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/s/${sessionId}/logs`);
+    const replayed = [];
+    ws.on('message', data => replayed.push(JSON.parse(data.toString())));
+    await waitForOpen(ws);
+    await waitUntil(() => replayed.length === 2);
+
+    assert.deepEqual(replayed.map(e => e.id), ['1', '2']);
+
+    ws.close();
+    server.close();
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,5 +65,23 @@ module.exports = [
             'no-underscore-dangle': 'off',
             'no-continue': 'off'
         }
+    },
+    // apps/client/public is browser-loaded (<script type="module">), not
+    // Node — scoped here rather than added to the shared globals above so
+    // Node-side no-undef checking stays strict everywhere else.
+    {
+        files: ['apps/client/public/**/*.js'],
+        languageOptions: {
+            sourceType: 'module',
+            globals: {
+                window: 'readonly',
+                document: 'readonly',
+                alert: 'readonly',
+                navigator: 'readonly',
+                location: 'readonly',
+                localStorage: 'readonly',
+                sessionStorage: 'readonly'
+            }
+        }
     }
 ];

--- a/examples/dockge/compose.yaml
+++ b/examples/dockge/compose.yaml
@@ -21,6 +21,8 @@ services:
     image: andrewshell/rsscloud-server:latest
     container_name: rsscloud-server
     restart: unless-stopped
+    networks:
+      - rsscloud-net
     ports:
       # host:container — change the host side if 5337 is taken; usually you'd
       # also front this with a reverse proxy terminating HTTPS.
@@ -59,6 +61,8 @@ services:
       dockerfile: apps/client/Dockerfile
     container_name: rsscloud-client
     restart: unless-stopped
+    networks:
+      - rsscloud-net
     depends_on:
       - rsscloud
     ports:
@@ -74,10 +78,21 @@ services:
       HUB_SERVER_URL: http://rsscloud:5337
       # SSRF egress protection is ON by default (recommended) and refuses
       # outbound requests to private addresses — including the Docker
-      # network's own subnet, which is how `rsscloud` above is reached. This
-      # allowlist is scoped to Docker's default bridge range; narrow it to
-      # this stack's actual subnet if you need tighter isolation.
-      CLIENT_FETCH_ALLOW_CIDRS: "172.16.0.0/12"
+      # network's own subnet, which is how `rsscloud` above is reached.
+      # Scoped to exactly this stack's dedicated subnet (defined below), not
+      # Docker's whole default bridge range, so pasting an arbitrary feed URL
+      # into Discover can't reach anything else on the host's private network.
+      CLIENT_FETCH_ALLOW_CIDRS: "172.28.5.0/24"
+
+networks:
+  # A dedicated, fixed subnet (rather than Docker's auto-assigned default
+  # bridge range) so CLIENT_FETCH_ALLOW_CIDRS above can be scoped tightly to
+  # just this stack instead of every private address Docker might use.
+  rsscloud-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.5.0/24
 
 volumes:
   rsscloud-data:

--- a/examples/dockge/compose.yaml
+++ b/examples/dockge/compose.yaml
@@ -1,13 +1,20 @@
-# rssCloud server — example stack for Dockge (https://github.com/louislam/dockge)
+# rssCloud server + test harness — example stack for Dockge (https://github.com/louislam/dockge)
 #
 # Usage:
 #   1. In Dockge, create a new stack (e.g. "rsscloud") and paste this file.
 #   2. Edit DOMAIN and HUB_URL below to your public hostname.
 #   3. Deploy. Subscriptions + stats persist in the named volume `rsscloud-data`.
 #
-# This pulls the published image rather than building, so it deploys without the
-# source tree. To pin a release, replace `:latest` with a version tag
-# (e.g. andrewshell/rsscloud-server:4.0.0).
+# The `rsscloud` service pulls the published image rather than building, so it
+# deploys without the source tree. To pin a release, replace `:latest` with a
+# version tag (e.g. andrewshell/rsscloud-server:4.0.0).
+#
+# The `client` service (the rssCloud/WebSub test harness, apps/client) has no
+# published image yet, so it builds from source instead — this stack must be
+# deployed from a checkout of the repo for that service to build. Point a
+# browser at it to test the paired hub, or edit its HUB_SERVER_URL/CLIENT_FETCH_ALLOW_CIDRS
+# to test a different one. Remove the `client` service entirely if you only
+# want the hub.
 
 services:
   rsscloud:
@@ -45,6 +52,32 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  client:
+    build:
+      context: ../..
+      dockerfile: apps/client/Dockerfile
+    container_name: rsscloud-client
+    restart: unless-stopped
+    depends_on:
+      - rsscloud
+    ports:
+      - "9000:9000"
+    environment:
+      # Externally-reachable hostname/port this harness advertises for its
+      # own callbacks and test feeds.
+      DOMAIN: cloud.example.com
+      # PORT: "9000"
+      # Reach the sibling `rsscloud` service by its Compose service name —
+      # override at runtime (the UI's server/hub override field) to test a
+      # different hub instead.
+      HUB_SERVER_URL: http://rsscloud:5337
+      # SSRF egress protection is ON by default (recommended) and refuses
+      # outbound requests to private addresses — including the Docker
+      # network's own subnet, which is how `rsscloud` above is reached. This
+      # allowlist is scoped to Docker's default bridge range; narrow it to
+      # this stack's actual subnet if you need tighter isolation.
+      CLIENT_FETCH_ALLOW_CIDRS: "172.16.0.0/12"
 
 volumes:
   rsscloud-data:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,18 +38,27 @@ importers:
 
   apps/client:
     dependencies:
+      '@rsscloud/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@rsscloud/xml-rpc':
         specifier: workspace:*
         version: link:../../packages/xml-rpc
       body-parser:
         specifier: ^2.2.2
         version: 2.2.2
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       express:
         specifier: ^4.22.2
         version: 4.22.2
       morgan:
         specifier: ^1.10.1
         version: 1.10.1
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -63,6 +72,9 @@ importers:
       nodemon:
         specifier: 3.1.14
         version: 3.1.14
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
 
   apps/e2e:
     devDependencies:


### PR DESCRIPTION
## Summary

- Replaces the two-box, dev-only UI in `apps/client` with a unified control (rssCloud REST/XML-RPC/WebSub), async JSON actions under `/s/:sessionId/actions/*` (no page navigation), feed-URL discovery, and a live combined incoming+outgoing traffic log via `@andrewshell/socklog` over a per-session WebSocket.
- Makes the harness safe to run as a public utility instead of a local-only dev tool: session-scoped state (no cross-user leakage), an SSRF-guarded outbound fetch reusing `@rsscloud/core`'s `createSafeFetch`, idle-404 + GC eviction for abandoned sessions (suspended while a live socklog connection is attached, so an overnight-monitoring tab never goes dark), and structural enforcement that `/actions/ping`/`/actions/publish` can only ever target this harness's own feed.
- Adds dotenv + Docker support (`apps/client/Dockerfile`, `.env.example`, a paired service in `examples/dockge/compose.yaml`).
- Reuses `apps/server`'s stylesheet; the control box is laid out as labeled fieldsets, and the socklog panel grows with content instead of a fixed height.

## Test plan

- [x] `pnpm --filter @rsscloud/client-app run test` — 73 passing
- [x] `pnpm run lint` / `pnpm run test:unit` / `pnpm run typecheck` — clean across all 6 workspace packages
- [x] Manual verification in a real browser against a real running hub: session redirect, protocol switching, Subscribe/Ping/Publish/Discover, subscriber-mode button hiding, live traffic log
- [x] `docker build` + `docker run` smoke test of `apps/client/Dockerfile`
- [x] Verified idle-404/GC-eviction suspension while a socklog socket is connected, via a real WebSocket client

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session-based client test harness with per-session protocol controls, WebSocket live log streaming, and session-scoped callbacks.
  * Introduced feed discovery helpers to detect RSSCloud and WebSub support from a feed URL.
* **Bug Fixes**
  * Improved session lifecycle behavior (idle expiry, garbage collection, and isolation) and hardened request verification flows.
  * Strengthened outbound request security with SSRF protections and configurable CIDR allow-listing.
* **Documentation**
  * Refreshed the client README, environment template, and Docker/Compose run guidance.
* **Tests**
  * Expanded automated coverage for discovery, SSRF guarding, sessions, and protocol actions.
* **Chores**
  * Updated linting for browser code and refined docker build context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->