### PR TITLE
feat(debug): add a session settings page for rssCloud/WebSub configur…

### DIFF
--- a/apps/debug/.env.example
+++ b/apps/debug/.env.example
@@ -16,9 +16,10 @@ DOMAIN=localhost
 PORT=9000
 
 # --- Default hub / WebSub target --------------------------------------------
-# Where actions go when the UI's server/hub override field is left blank.
-# Overridden per-action at runtime by that field — this is just the default
-# (e.g. for testing this repo's own hub locally).
+# Seeds each new session's default settings (rssCloud ping/subscribe/RPC2
+# URLs, WebSub hub URL) computed on first visit — from the session's
+# Settings page, override any of these for that session alone (e.g. to test
+# a hub deployed live instead of this repo's own hub running locally).
 HUB_SERVER_URL=http://localhost:5337
 
 # --- SSRF egress guard: allow loopback for local dev ------------------------

--- a/apps/debug/README.md
+++ b/apps/debug/README.md
@@ -6,12 +6,18 @@ publisher end, the mirror of `@rsscloud/core` (the hub end). Unlike most of this
 it's designed to be deployable as a **public utility**: it can test a hub running locally,
 a hub deployed live, or any third party's rssCloud/WebSub implementation.
 
-The Express app ([`debug.js`](debug.js)) serves one unified control box — pick a protocol
-(rssCloud REST, rssCloud XML-RPC, or WebSub), point it at this harness's own test feed or an
-arbitrary external one, and Subscribe/Ping/Publish/Unsubscribe. Every action is asynchronous
-(no page navigation); the outcome — and everything this harness receives — shows up as a
-combined, live traffic log via [`@andrewshell/socklog`](https://www.npmjs.com/package/@andrewshell/socklog).
-All the protocol wire work lives in [`lib/`](lib/) and is reusable on its own.
+The Express app ([`debug.js`](debug.js)) serves a simple three-row action box (Feed / rssCloud /
+WebSub) driven by a per-session **Settings** page, reachable via the gear icon next to the
+heading. Settings start at computed defaults (based on `HUB_SERVER_URL`) and can point this
+session's own test feed or an arbitrary external one at whichever rssCloud protocol (REST or
+XML-RPC) and/or WebSub hub you're testing — entering an external feed URL triggers discovery
+(traditional `<cloud>` or the newer `<source:cloud>`, a WebSub hub via `Link` header or feed
+element) to prefill the rest of the form. Saving settings navigates back to the main page,
+where the row of buttons acts against whatever's configured; the outcome — and everything this
+harness receives — shows up as a live traffic log via
+[`@andrewshell/socklog`](https://www.npmjs.com/package/@andrewshell/socklog) (purely live, not
+stored server-side — a reload always starts with an empty log). All the protocol wire work
+lives in [`lib/`](lib/) and is reusable on its own.
 
 ## Sessions
 
@@ -71,33 +77,54 @@ this harness with the hub server.
 
 `require('./lib')` exposes these helpers (CommonJS):
 
-- **`createRssCloudClient({ serverUrl, fetch? })`** — send `pleaseNotify` (subscribe) and
-  `ping` (publish) to a hub over an injectable `fetch`. Returns `{ pleaseNotify, ping }`.
+- **`createRssCloudClient({ serverUrl?, fetch? })`** — send `pleaseNotify` (subscribe) and
+  `ping` (publish) to a hub over an injectable `fetch`. Returns `{ pleaseNotify, ping }`; both
+  accept an explicit `url` to target instead of `serverUrl` + its conventional suffix (so
+  `serverUrl` is only required when no call ever passes one), and an `accept` (`'xml'|'json'`)
+  that sets the `Accept` header on a REST call — the outgoing body is always urlencoded
+  regardless, since the real wire protocol only ever parses that.
 - **`createWebSubClient({ serverUrl, path?, fetch? })`** — send WebSub `hub.*` requests to a
   hub's front door (`path` defaults to `/websub`). Returns `{ subscribe, unsubscribe, publish }`;
   each resolves to the hub's raw reply (`{ status, body }`) and does **not** throw on a non-2xx.
 - **`readVerification(query)`** — given a callback GET's query, return
   `{ mode, topic, challenge, leaseSeconds }` when it's a WebSub intent-verification request
   (the subscriber must echo `challenge` verbatim), else `null`.
-- **`renderCloudFeed(feed)`** — emit an RSS 2.0 document carrying the `<cloud>` element that
-  advertises a hub. Pass `hub` (a URL) to also advertise a WebSub hub via
-  `<atom:link rel="hub">` plus a `rel="self"` link.
+- **`renderCloudFeed(feed)`** — emit an RSS 2.0 document, optionally carrying the `<cloud>`
+  element that advertises a hub (pass `cloud`; omitted entirely when not given). Pass `hub`
+  (a URL) to also advertise a WebSub hub via `<atom:link rel="hub">` plus a `rel="self"` link.
 - **`buildNotifyResponse(success)`** — build the XML-RPC notify acknowledgement a subscriber
   returns to the hub.
 - **`discoverFeed({ url, fetch? })`** — fetch an arbitrary feed URL and report what it
   advertises: `{ rssCloud: {domain,port,path,registerProcedure,protocol} | null, webSub:
-  {hubUrl} | null, error? }`. Backs the UI's "enter a feed URL" discovery action.
-- **`parseFeedDiscovery(xmlText)`** — the parsing half of `discoverFeed`, given an
-  already-fetched body.
+  {hubUrl} | null, selfUrl?, error? }`. rssCloud discovery prefers a `<source:cloud>` element
+  (the [source.scripting.com](https://source.scripting.com/) convention, resolved by its actual
+  bound namespace prefix) over a traditional `<cloud>` when both are present; WebSub hub/self
+  discovery prefers the HTTP `Link` response header over a feed-embedded link when both are
+  present. Backs the settings page's Feed-URL-blur discovery action.
+- **`parseFeedDiscovery(xmlText, { linkHeader? })`** — the parsing half of `discoverFeed`,
+  given an already-fetched body and optionally its response's `Link` header.
+
+Two more `lib/` modules hold the session-settings model (not part of the portable barrel above,
+since they're this app's own domain shape, not reusable protocol plumbing):
+
+- **`lib/settings.js`**'s `computeDefaultSettings({ sessionId, domain, port, hubServerUrl })` —
+  the settings a new session starts with; `applyDiscoveryToSettings(settings, discoveryResult)`
+  — merges a `discoverFeed()` result into a settings snapshot; `isSelfHostedFeedUrl`/
+  `feedNameFromSelfHostedUrl`/`selfHostedPrefixes` — whether/what a feed URL names this
+  session's own served feed.
+- **`lib/link-header.js`**'s `parseLinkHeader(value)`/`findLinkByRel(links, rel)` — parse an
+  HTTP `Link` header's `rel="hub"`/`rel="self"` link-values (handles multiple comma-separated
+  values per RFC 8288).
 
 Two more app-root modules (not part of the portable `lib/` barrel, since they're
 Express/`ws`-coupled):
 
-- **`lib/session-store.js`**'s `createSessionStore({ now?, idGenerator? })` — the in-memory
-  per-session state (request log, feed items, WebSub secrets, idle tracking) described above.
+- **`lib/session-store.js`**'s `createSessionStore({ now?, idGenerator?, buildDefaultSettings? })`
+  — the in-memory per-session state (settings, feed items, WebSub secrets, idle tracking)
+  described above. The traffic log itself is never stored here — see `session-sockets.js`.
 - **`session-sockets.js`**'s `createSessionSockets({ sessionStore })` — the per-session
   socklog WebSocket feed (`/s/:id/logs`), returning `{ attach(server), broadcast(sessionId,
-  entry) }`.
+  entry) }`. Purely live — a socket connecting late sees only what's broadcast after it connects.
 - **`lib/guarded-fetch.js`**'s `createGuardedFetch({ allowCidrs?, timeoutMs? })` — the
   SSRF-guarded fetch described above.
 
@@ -110,12 +137,12 @@ const hub = createWebSubClient({ serverUrl: 'http://localhost:5337' });
 
 await hub.subscribe({
     callbackUrl: 'http://localhost:9000/s/<session-id>/websub-callback',
-    topicUrl: 'http://localhost:9000/s/<session-id>/rss-01.xml',
+    topicUrl: 'http://localhost:9000/s/<session-id>/rss.xml',
     leaseSeconds: 3600, // optional; the hub clamps to its configured bounds
     secret: 's3cr3t' // optional; opts into a signed X-Hub-Signature delivery
 });
 
-await hub.publish({ topicUrl: 'http://localhost:9000/s/<session-id>/rss-01.xml' }); // hub.mode=publish
+await hub.publish({ topicUrl: 'http://localhost:9000/s/<session-id>/rss.xml' }); // hub.mode=publish
 await hub.unsubscribe({ callbackUrl: '…', topicUrl: '…' });
 ```
 
@@ -155,9 +182,11 @@ await client.ping({ transport: 'xml-rpc', feedUrl: '…' }); // /RPC2
 ```js
 const { discoverFeed } = require('./lib');
 
-const { rssCloud, webSub, error } = await discoverFeed({
+const { rssCloud, webSub, selfUrl, error } = await discoverFeed({
     url: 'https://feed.example/rss'
 });
-// rssCloud: { domain, port, path, registerProcedure, protocol } | null
-// webSub:   { hubUrl } | null
+// rssCloud: { domain, port, path, registerProcedure, protocol } | null — <source:cloud> wins
+//           over a traditional <cloud> when a feed advertises both
+// webSub:   { hubUrl } | null — a Link header wins over a feed-embedded link
+// selfUrl:  the feed's declared canonical URL (rel="self"), if any
 ```

--- a/apps/debug/debug.hub-config.test.js
+++ b/apps/debug/debug.hub-config.test.js
@@ -9,11 +9,11 @@ const assert = require('node:assert/strict');
 const { createApp } = require('./debug');
 const request = require('supertest');
 
-test('the served test feed\'s <cloud> element derives domain/port from HUB_SERVER_URL', async() => {
+test('the served test feed\'s <cloud> element derives domain/port from the session\'s default rssCloud settings (HUB_SERVER_URL)', async() => {
     const app = createApp();
 
     await request(app).get('/s/cloud-config-session');
-    const res = await request(app).get('/s/cloud-config-session/rss-01.xml');
+    const res = await request(app).get('/s/cloud-config-session/rss.xml');
 
     assert.match(res.text, /<cloud domain="hub\.example\.org" port="8080"/);
 });

--- a/apps/debug/debug.js
+++ b/apps/debug/debug.js
@@ -48,6 +48,21 @@ function cloudFromSettings(rssCloud) {
     };
 }
 
+// A blank or malformed URL here would otherwise only surface later, as a
+// 500 from cloudFromSettings the next time the self-served feed is
+// requested — reject it at save time instead.
+function isValidHttpUrl(value) {
+    if (!value) {
+        return false;
+    }
+    try {
+        const parsed = new URL(value);
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
 // This session's callback URL the hub notifies for WebSub content
 // distribution and intent verification.
 function webSubCallbackUrl(sessionId) {
@@ -262,7 +277,7 @@ function renderPage(sessionId, wsUrl, settings, { isSelfHosted, showPing, lastUp
 // (computed defaults on first visit, whatever was last saved after that).
 // Protocol-dependent field visibility is toggled client-side (public/settings.js)
 // since it must react live to the form's own dropdown/checkbox changes.
-function renderSettingsPage(sessionId, settings) {
+function renderSettingsPage(sessionId, settings, { error } = {}) {
     const ctx = { domain: config.domain, port: config.port, sessionId };
     const context = {
         selfHostedPrefixes: selfHostedPrefixes(ctx),
@@ -345,13 +360,13 @@ function renderSettingsPage(sessionId, settings) {
                     </label>
                     <label for="webSubSecret">
                         secret
-                        <input type="text" id="webSubSecret" name="webSubSecret" value="${escapeHtml(settings.webSub.secret ?? '')}" placeholder="optional">
+                        <input type="password" id="webSubSecret" name="webSubSecret" value="${escapeHtml(settings.webSub.secret ?? '')}" placeholder="optional">
                     </label>
                 </div>
             </div>
         </fieldset>
 
-        <div id="actionError" class="action-error" role="alert" hidden></div>
+        <div id="actionError" class="action-error" role="alert"${error ? '' : ' hidden'}>${error ? escapeHtml(error) : ''}</div>
         <div class="actions">
             <button type="submit">Save</button>
             <a href="/s/${escapeHtml(sessionId)}">Cancel</a>
@@ -532,16 +547,43 @@ function createApp({
     // mode doesn't support nested keys, so the form uses flat field names,
     // reassembled here into the nested settings shape.
     sessionRouter.post('/settings', ensureSession, urlencodedParser, (req, res) => {
+        const rssCloud = {
+            disabled: req.body.rssCloudDisabled === 'on',
+            protocol: req.body.rssCloudProtocol,
+            accepts: req.body.rssCloudAccepts,
+            pingUrl: req.body.rssCloudPingUrl || '',
+            subscribeUrl: req.body.rssCloudSubscribeUrl,
+            rpcUrl: req.body.rssCloudRpcUrl
+        };
+
+        // Whichever URL cloudFromSettings will actually read (rpcUrl for
+        // xml-rpc, else subscribeUrl) must be valid before it's saved — a
+        // blank/malformed one otherwise only surfaces later as a 500 the
+        // next time the self-served feed is requested.
+        if (!rssCloud.disabled) {
+            const requiredUrl = rssCloud.protocol === 'xml-rpc' ? rssCloud.rpcUrl : rssCloud.subscribeUrl;
+            if (!isValidHttpUrl(requiredUrl)) {
+                res.status(400).type('html').send(renderSettingsPage(req.params.sessionId, {
+                    feedUrl: req.body.feedUrl,
+                    rssCloud,
+                    webSub: {
+                        disabled: req.body.webSubDisabled === 'on',
+                        hubUrl: req.body.webSubHubUrl,
+                        leaseSeconds: req.body.webSubLeaseSeconds || '',
+                        secret: req.body.webSubSecret || ''
+                    }
+                }, {
+                    error: rssCloud.protocol === 'xml-rpc'
+                        ? 'rssCloud is enabled but the RPC2 endpoint URL is missing or invalid.'
+                        : 'rssCloud is enabled but the subscribe URL is missing or invalid.'
+                }));
+                return;
+            }
+        }
+
         req.session.settings = {
             feedUrl: req.body.feedUrl,
-            rssCloud: {
-                disabled: req.body.rssCloudDisabled === 'on',
-                protocol: req.body.rssCloudProtocol,
-                accepts: req.body.rssCloudAccepts,
-                pingUrl: req.body.rssCloudPingUrl || '',
-                subscribeUrl: req.body.rssCloudSubscribeUrl,
-                rpcUrl: req.body.rssCloudRpcUrl
-            },
+            rssCloud,
             webSub: {
                 disabled: req.body.webSubDisabled === 'on',
                 hubUrl: req.body.webSubHubUrl,

--- a/apps/debug/debug.js
+++ b/apps/debug/debug.js
@@ -16,6 +16,13 @@ const bodyParser = require('body-parser'),
         renderCloudFeed,
         discoverFeed
     } = require('./lib'),
+    {
+        applyDiscoveryToSettings,
+        isSelfHostedFeedUrl,
+        feedNameFromSelfHostedUrl,
+        selfHostedPrefixes,
+        computeDefaultSettings
+    } = require('./lib/settings'),
     textParser = bodyParser.text({ type: '*/xml' }),
     // Content distribution arrives with the origin feed's Content-Type relayed
     // verbatim, so the callback parses any media type as a raw string to log it.
@@ -23,24 +30,28 @@ const bodyParser = require('body-parser'),
     urlencodedParser = bodyParser.urlencoded({ extended: false }),
     jsonParser = bodyParser.json();
 
-// The hub's WebSub front door, advertised in feeds via <atom:link rel="hub">.
-const hubUrl = `${config.hubServerUrl}/websub`;
-// The hub's origin, decomposed for the <cloud> element's domain/port — its
-// XML-RPC front door is always /RPC2, the rssCloud convention.
-const hubOrigin = new URL(config.hubServerUrl);
-const hubPort =
-    Number(hubOrigin.port) || (hubOrigin.protocol === 'https:' ? 443 : 80);
+// Derive a self-served test feed's <cloud> element from a session's own
+// rssCloud settings — undefined (omitted entirely) when rssCloud is
+// disabled. The RPC2 endpoint doubles as both ping and subscribe front door.
+function cloudFromSettings(rssCloud) {
+    if (rssCloud.disabled) {
+        return undefined;
+    }
+    const useXmlRpc = rssCloud.protocol === 'xml-rpc';
+    const target = new URL(useXmlRpc ? rssCloud.rpcUrl : rssCloud.subscribeUrl);
+    return {
+        domain: target.hostname,
+        port: Number(target.port) || (target.protocol === 'https:' ? 443 : 80),
+        path: target.pathname,
+        registerProcedure: useXmlRpc ? 'rssCloud.pleaseNotify' : '',
+        protocol: rssCloud.protocol
+    };
+}
 
 // This session's callback URL the hub notifies for WebSub content
 // distribution and intent verification.
 function webSubCallbackUrl(sessionId) {
     return `http://${config.domain}:${config.port}/s/${sessionId}/websub-callback`;
-}
-
-// Build the feed URL an action targets: the caller's own external feedUrl
-// when given (subscriber mode), else this session's own test feed.
-function resolveFeedUrl(sessionId, { feedUrl, feedName }) {
-    return feedUrl || `http://${config.domain}:${config.port}/s/${sessionId}/${feedName || 'rss-01.xml'}`;
 }
 
 // Pull the topic URL out of a delivery's Link header (`<url>; rel="self"`).
@@ -80,17 +91,9 @@ function escapeHtml(text) {
         .replace(/'/g, '&#039;');
 }
 
-// Render the unified control box + live traffic log for a session.
-// `hubServerUrl`/`hubUrl` prefill the server/hub override field with this
-// harness's own defaults; the Discover action overwrites it client-side.
-function renderPage(sessionId, wsUrl) {
-    return `<!DOCTYPE html>
-<html>
-<head>
-    <title>rssCloud Debug Harness</title>
-    <link href="/css/style.css" rel="stylesheet" />
-    <style>
-        /* Debug-harness-specific additions layered on the shared server stylesheet. */
+// Debug-harness-specific additions layered on the shared server stylesheet,
+// shared between the main page and the settings page.
+const debugStyles = `
         select {
             width: 100%;
             padding: 10px;
@@ -143,65 +146,96 @@ function renderPage(sessionId, wsUrl) {
             gap: 10px;
             flex-wrap: wrap;
         }
-    </style>
+        /* The settings form's own Save/Cancel bar (a direct child of <form>,
+           unlike the per-fieldset action rows nested inside it) needs space
+           from the last fieldset above it, and vertical centering so the
+           plain-text Cancel link lines up with the Save button. */
+        form > .actions {
+            margin-top: 20px;
+            align-items: center;
+        }
+        .page-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .page-header h1 {
+            margin-bottom: 0;
+            border-bottom: none;
+        }
+        .settings-link {
+            color: #2c3e50;
+            line-height: 0;
+        }
+        /* style.css sets an explicit display on label/div, which otherwise
+           overrides the [hidden] attribute's implicit display:none. */
+        .rsscloud-rest-only[hidden],
+        .rsscloud-xmlrpc-only[hidden],
+        .websub-fields-body[hidden] {
+            display: none;
+        }
+`;
+
+// A generic gear/cog icon — the settings page's entry point, right-justified
+// from the heading.
+const gearIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" fill="currentColor" aria-hidden="true">
+    <path d="M19.14 12.94c.04-.3.06-.61.06-.94s-.02-.64-.07-.94l2.03-1.58a.5.5 0 00.12-.64l-1.92-3.32a.5.5 0 00-.6-.22l-2.39.96a7.03 7.03 0 00-1.62-.94l-.36-2.54a.5.5 0 00-.5-.42h-3.84a.5.5 0 00-.5.42l-.36 2.54c-.59.24-1.13.56-1.62.94l-2.39-.96a.5.5 0 00-.6.22L2.66 8.84a.5.5 0 00.12.64l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94L2.76 14.5a.5.5 0 00-.12.64l1.92 3.32c.14.24.42.34.68.22l2.39-.96c.5.38 1.04.7 1.62.94l.36 2.54c.05.28.27.42.5.42h3.84c.28 0 .46-.14.5-.42l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.28.12.54 0 .68-.22l1.92-3.32a.5.5 0 00-.12-.64l-2.02-1.58zM12 15.5A3.5 3.5 0 1112 8.5a3.5 3.5 0 010 7z"/>
+</svg>`;
+
+// Render the simplified control box (Feed / rssCloud / WebSub rows, each
+// driven entirely by the session's saved settings) + live traffic log.
+// Row/button visibility is computed server-side by the caller (see
+// `GET /` below) and baked into the markup, not toggled client-side.
+function renderPage(sessionId, wsUrl, settings, { isSelfHosted, showPing, lastUpdatedAt }) {
+    const feedRow = isSelfHosted
+        ? `<p class="feed-url">Feed URL: <code>${escapeHtml(settings.feedUrl)}</code></p>
+            <div class="actions">
+                <button type="button" id="updateFeedButton">Update Feed</button>
+            </div>
+            <p class="feed-url">Last updated: <span id="feedLastUpdated">${escapeHtml(lastUpdatedAt.toISOString())}</span></p>`
+        : `<p class="feed-url">External feed: <code>${escapeHtml(settings.feedUrl)}</code></p>`;
+
+    const rssCloudRow = settings.rssCloud.disabled
+        ? ''
+        : `<fieldset>
+            <legend>rssCloud</legend>
+            <div class="actions">
+                <button type="button" id="rsscloudSubscribeButton">Subscribe</button>
+                ${showPing ? '<button type="button" id="rsscloudPingButton">Ping</button>' : ''}
+            </div>
+        </fieldset>`;
+
+    const webSubRow = settings.webSub.disabled
+        ? ''
+        : `<fieldset>
+            <legend>WebSub</legend>
+            <div class="actions">
+                <button type="button" id="websubSubscribeButton">Subscribe</button>
+                <button type="button" id="websubUnsubscribeButton">Unsubscribe</button>
+                <button type="button" id="websubPublishButton">Publish</button>
+            </div>
+        </fieldset>`;
+
+    return `<!DOCTYPE html>
+<html>
+<head>
+    <title>rssCloud Debug Harness</title>
+    <link href="/css/style.css" rel="stylesheet" />
+    <style>${debugStyles}</style>
 </head>
 <body data-session-id="${escapeHtml(sessionId)}">
-    <h1>rssCloud Debug Harness</h1>
+    <div class="page-header">
+        <h1>rssCloud Debug Harness</h1>
+        <a class="settings-link" href="/s/${escapeHtml(sessionId)}/settings" aria-label="Settings" title="Settings">${gearIconSvg}</a>
+    </div>
 
     <div class="controls">
         <fieldset>
-            <legend>Target</legend>
-            <div class="form-row">
-                <label for="protocol">
-                    Protocol
-                    <select id="protocol">
-                        <option value="rsscloud-rest">rssCloud REST</option>
-                        <option value="rsscloud-xml-rpc">rssCloud XML-RPC</option>
-                        <option value="websub">WebSub</option>
-                    </select>
-                </label>
-                <label for="serverOverride">
-                    Server/hub override
-                    <input type="text" id="serverOverride" placeholder="${escapeHtml(config.hubServerUrl)}">
-                </label>
-            </div>
-        </fieldset>
-
-        <fieldset>
             <legend>Feed</legend>
-            <label for="feedUrl">
-                Feed URL (external — leave blank to use this harness's own test feed)
-            </label>
-            <div class="input-with-button">
-                <input type="text" id="feedUrl" placeholder="https://example.com/feed.xml">
-                <button type="button" id="discoverButton">Discover</button>
-            </div>
-            <label for="feedName">
-                Feed name (own test feed)
-                <input type="text" id="feedName" value="rss-01.xml">
-            </label>
+            ${feedRow}
         </fieldset>
-
-        <fieldset class="websub-only">
-            <legend>WebSub options</legend>
-            <div class="form-row">
-                <label for="leaseSeconds">
-                    lease_seconds
-                    <input type="text" id="leaseSeconds" placeholder="optional">
-                </label>
-                <label for="secret">
-                    secret
-                    <input type="text" id="secret" placeholder="optional">
-                </label>
-            </div>
-        </fieldset>
-
-        <div class="actions">
-            <button type="button" id="subscribeButton">Subscribe</button>
-            <button type="button" id="unsubscribeButton" class="websub-only">Unsubscribe</button>
-            <button type="button" id="pingButton" class="rsscloud-only">Ping</button>
-            <button type="button" id="publishButton" class="websub-only">Publish</button>
-        </div>
+        ${rssCloudRow}
+        ${webSubRow}
     </div>
 
     <div id="actionError" class="action-error" role="alert" hidden></div>
@@ -220,6 +254,111 @@ function renderPage(sessionId, wsUrl) {
     </div>
 
     <script type="module" src="/app.js"></script>
+</body>
+</html>`;
+}
+
+// Render the settings page — starts from the session's current settings
+// (computed defaults on first visit, whatever was last saved after that).
+// Protocol-dependent field visibility is toggled client-side (public/settings.js)
+// since it must react live to the form's own dropdown/checkbox changes.
+function renderSettingsPage(sessionId, settings) {
+    const ctx = { domain: config.domain, port: config.port, sessionId };
+    const context = {
+        selfHostedPrefixes: selfHostedPrefixes(ctx),
+        defaultSettings: computeDefaultSettings({ ...ctx, hubServerUrl: config.hubServerUrl })
+    };
+
+    return `<!DOCTYPE html>
+<html>
+<head>
+    <title>rssCloud Debug Harness — Settings</title>
+    <link href="/css/style.css" rel="stylesheet" />
+    <style>${debugStyles}</style>
+</head>
+<body>
+    <h1>rssCloud Debug Harness — Settings</h1>
+
+    <form method="POST" action="/s/${escapeHtml(sessionId)}/settings" data-context='${escapeHtml(JSON.stringify(context))}'>
+        <label for="feedUrl">Feed URL</label>
+        <div class="input-with-button">
+            <input type="text" id="feedUrl" name="feedUrl" value="${escapeHtml(settings.feedUrl)}">
+            <button type="button" id="feedUrlResetButton"${isSelfHostedFeedUrl(settings.feedUrl, ctx) ? ' disabled' : ''}>Reset</button>
+        </div>
+
+        <fieldset id="rsscloudFields">
+            <legend>rssCloud</legend>
+            <label>
+                <input type="checkbox" id="rssCloudDisabled" name="rssCloudDisabled" ${settings.rssCloud.disabled ? 'checked' : ''}>
+                Disabled
+            </label>
+            <div class="rsscloud-fields-body">
+                <div class="form-row">
+                    <label for="rssCloudProtocol">
+                        Protocol
+                        <select id="rssCloudProtocol" name="rssCloudProtocol">
+                            <option value="http-post" ${settings.rssCloud.protocol === 'http-post' ? 'selected' : ''}>http-post</option>
+                            <option value="https-post" ${settings.rssCloud.protocol === 'https-post' ? 'selected' : ''}>https-post</option>
+                            <option value="xml-rpc" ${settings.rssCloud.protocol === 'xml-rpc' ? 'selected' : ''}>xml-rpc</option>
+                        </select>
+                    </label>
+                    <label for="rssCloudAccepts" class="rsscloud-rest-only">
+                        Accepts
+                        <select id="rssCloudAccepts" name="rssCloudAccepts">
+                            <option value="xml" ${settings.rssCloud.accepts === 'xml' ? 'selected' : ''}>xml</option>
+                            <option value="json" ${settings.rssCloud.accepts === 'json' ? 'selected' : ''}>json</option>
+                        </select>
+                    </label>
+                </div>
+                <div class="form-row rsscloud-rest-only">
+                    <label for="rssCloudPingUrl">
+                        Ping URL
+                        <input type="text" id="rssCloudPingUrl" name="rssCloudPingUrl" value="${escapeHtml(settings.rssCloud.pingUrl)}">
+                    </label>
+                    <label for="rssCloudSubscribeUrl">
+                        Subscribe URL
+                        <input type="text" id="rssCloudSubscribeUrl" name="rssCloudSubscribeUrl" value="${escapeHtml(settings.rssCloud.subscribeUrl)}">
+                    </label>
+                </div>
+                <label for="rssCloudRpcUrl" class="rsscloud-xmlrpc-only">
+                    RPC2 endpoint
+                    <input type="text" id="rssCloudRpcUrl" name="rssCloudRpcUrl" value="${escapeHtml(settings.rssCloud.rpcUrl)}">
+                </label>
+            </div>
+        </fieldset>
+
+        <fieldset id="webSubFields">
+            <legend>WebSub</legend>
+            <label>
+                <input type="checkbox" id="webSubDisabled" name="webSubDisabled" ${settings.webSub.disabled ? 'checked' : ''}>
+                Disabled
+            </label>
+            <div class="websub-fields-body">
+                <label for="webSubHubUrl">
+                    Hub URL
+                    <input type="text" id="webSubHubUrl" name="webSubHubUrl" value="${escapeHtml(settings.webSub.hubUrl)}">
+                </label>
+                <div class="form-row">
+                    <label for="webSubLeaseSeconds">
+                        lease_seconds
+                        <input type="text" id="webSubLeaseSeconds" name="webSubLeaseSeconds" value="${escapeHtml(String(settings.webSub.leaseSeconds ?? ''))}" placeholder="optional">
+                    </label>
+                    <label for="webSubSecret">
+                        secret
+                        <input type="text" id="webSubSecret" name="webSubSecret" value="${escapeHtml(settings.webSub.secret ?? '')}" placeholder="optional">
+                    </label>
+                </div>
+            </div>
+        </fieldset>
+
+        <div id="actionError" class="action-error" role="alert" hidden></div>
+        <div class="actions">
+            <button type="submit">Save</button>
+            <a href="/s/${escapeHtml(sessionId)}">Cancel</a>
+        </div>
+    </form>
+
+    <script type="module" src="/settings.js"></script>
 </body>
 </html>`;
 }
@@ -368,74 +507,83 @@ function createApp({
 
     // Route: Home page with UI
     sessionRouter.get('/', ensureSession, (req, res) => {
+        const sessionId = req.params.sessionId;
         const wsProtocol = req.protocol === 'https' ? 'wss' : 'ws';
-        const wsUrl = `${wsProtocol}://${req.get('host')}/s/${req.params.sessionId}/logs`;
-        res.type('html').send(renderPage(req.params.sessionId, wsUrl));
+        const wsUrl = `${wsProtocol}://${req.get('host')}/s/${sessionId}/logs`;
+        const { settings } = req.session;
+        const ctx = { domain: config.domain, port: config.port, sessionId };
+        const isSelfHosted = isSelfHostedFeedUrl(settings.feedUrl, ctx);
+        const showPing = settings.rssCloud.protocol === 'xml-rpc' || Boolean(settings.rssCloud.pingUrl);
+        const lastUpdatedAt = isSelfHosted
+            ? req.session.feedLastUpdatedAt[feedNameFromSelfHostedUrl(settings.feedUrl, ctx)] ?? new Date(req.session.createdAt)
+            : undefined;
+        res.type('html').send(
+            renderPage(sessionId, wsUrl, settings, { isSelfHosted, showPing, lastUpdatedAt })
+        );
     });
 
-    // Route: parse an arbitrary feed URL for rssCloud/WebSub support. Feeds
-    // this outbound fetch through the same SSRF-guarded fetch as every other
-    // action, since the URL is user-supplied.
-    sessionRouter.post('/actions/discover', ensureSession, jsonParser, async(req, res) => {
-        const sessionId = req.params.sessionId;
-        const { feedUrl } = req.body;
-        const logId = crypto.randomUUID();
+    // Route: settings page — starts from the session's current settings.
+    sessionRouter.get('/settings', ensureSession, (req, res) => {
+        res.type('html').send(renderSettingsPage(req.params.sessionId, req.session.settings));
+    });
 
-        broadcastOutgoingRequest(sessionId, {
-            id: logId,
-            timestamp: new Date().toISOString(),
-            method: 'GET',
-            url: feedUrl,
-            body: { action: 'discover', feedUrl }
-        });
+    // Route: Save — a real <form> POST (not a fetch action), so the browser
+    // navigates back to the main page on success. body-parser's urlencoded
+    // mode doesn't support nested keys, so the form uses flat field names,
+    // reassembled here into the nested settings shape.
+    sessionRouter.post('/settings', ensureSession, urlencodedParser, (req, res) => {
+        req.session.settings = {
+            feedUrl: req.body.feedUrl,
+            rssCloud: {
+                disabled: req.body.rssCloudDisabled === 'on',
+                protocol: req.body.rssCloudProtocol,
+                accepts: req.body.rssCloudAccepts,
+                pingUrl: req.body.rssCloudPingUrl || '',
+                subscribeUrl: req.body.rssCloudSubscribeUrl,
+                rpcUrl: req.body.rssCloudRpcUrl
+            },
+            webSub: {
+                disabled: req.body.webSubDisabled === 'on',
+                hubUrl: req.body.webSubHubUrl,
+                leaseSeconds: req.body.webSubLeaseSeconds || '',
+                secret: req.body.webSubSecret || ''
+            }
+        };
+        res.redirect(302, `/s/${req.params.sessionId}`);
+    });
+
+    // Route: preview what settings a feed URL would produce, for the
+    // settings page's Feed-URL-blur discovery. Never writes
+    // req.session.settings — only POST /settings (Save) persists anything.
+    sessionRouter.post('/actions/discover-settings', ensureSession, jsonParser, async(req, res) => {
+        const { feedUrl, currentSettings } = req.body;
 
         try {
             const result = await discoverFeed({ url: feedUrl, fetch });
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                body: result
-            });
-            res.json(result);
+            if (result.error) {
+                res.json({ settings: null, error: result.error });
+                return;
+            }
+            res.json({ settings: applyDiscoveryToSettings(currentSettings, result) });
         } catch (error) {
-            const message = describeActionError(error);
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                error: message
-            });
-            res.json({ rssCloud: null, webSub: null, error: message });
+            res.json({ settings: null, error: describeActionError(error) });
         }
     });
 
-    // Route: unified Subscribe action — branches by the selected protocol.
-    // `server` optionally overrides the target: for rssCloud this is the hub
-    // origin (pleaseNotify/RPC2 base); for WebSub it's the full hub front-door
-    // URL (path defaults to '' so it isn't double-appended).
-    sessionRouter.post('/actions/subscribe', ensureSession, jsonParser, async(req, res) => {
-        const sessionId = req.params.sessionId;
-        const { protocol, server: serverOverride, leaseSeconds, secret } =
-            req.body;
-        const feedUrl = resolveFeedUrl(sessionId, req.body);
+    // Shared by every settings-driven action below: broadcasts the
+    // request/response pair around `call()`, and never mutates session state
+    // (via `onSuccess`) on the strength of a request that might still fail.
+    function logAndRespondAction(sessionId, res, action, targetUrl, requestBody, call, onSuccess) {
         const logId = crypto.randomUUID();
-
-        // `onSuccess`, when given, runs only once `call()` resolves without
-        // throwing — session state (e.g. the WebSub secret) must never be
-        // mutated on the strength of a request that might still fail.
-        async function logAndRespond(action, targetUrl, requestBody, call, onSuccess) {
-            broadcastOutgoingRequest(sessionId, {
-                id: logId,
-                timestamp: new Date().toISOString(),
-                method: 'POST',
-                url: targetUrl,
-                body: { action, ...requestBody }
-            });
-            try {
-                const result = await call();
+        broadcastOutgoingRequest(sessionId, {
+            id: logId,
+            timestamp: new Date().toISOString(),
+            method: 'POST',
+            url: targetUrl,
+            body: { action, ...requestBody }
+        });
+        return call()
+            .then(result => {
                 onSuccess?.(result);
                 broadcast(sessionId, {
                     id: logId,
@@ -445,7 +593,8 @@ function createApp({
                     ...result
                 });
                 res.json(result);
-            } catch (error) {
+            })
+            .catch(error => {
                 // An egress-guard refusal carries an actionable hint (set
                 // DEBUG_FETCH_ALLOW_CIDRS) so the failure isn't mistaken for a
                 // success in both the traffic log and the browser banner.
@@ -458,46 +607,29 @@ function createApp({
                     error: message
                 });
                 res.json({ error: message });
-            }
-        }
-
-        if (protocol === 'websub') {
-            const hub = createWebSubClient({
-                serverUrl: serverOverride || config.hubServerUrl,
-                path: serverOverride ? '' : undefined,
-                fetch
             });
-            await logAndRespond(
-                'websub-subscribe',
-                serverOverride || hubUrl,
-                // Redact the secret in the logged/broadcast copy — it's still
-                // sent verbatim to the hub below, just never echoed into the
-                // traffic log or session.requestLog.
-                { topicUrl: feedUrl, leaseSeconds, secret: secret ? '(redacted)' : undefined },
-                () => hub.subscribe({
-                    callbackUrl: webSubCallbackUrl(sessionId),
-                    topicUrl: feedUrl,
-                    leaseSeconds,
-                    secret
-                }),
-                () => {
-                    if (secret) {
-                        req.session.webSubSecrets[feedUrl] = secret;
-                    } else {
-                        delete req.session.webSubSecrets[feedUrl];
-                    }
-                }
-            );
+    }
+
+    // Route: rssCloud Subscribe — targets whichever endpoint the session's
+    // settings configure (the RPC2 endpoint for xml-rpc, else the configured
+    // subscribe URL).
+    sessionRouter.post('/actions/rsscloud-subscribe', ensureSession, (req, res) => {
+        const sessionId = req.params.sessionId;
+        const { settings } = req.session;
+        const { disabled, protocol, accepts, subscribeUrl, rpcUrl } = settings.rssCloud;
+
+        if (disabled) {
+            res.json({ error: 'rssCloud is disabled in settings' });
             return;
         }
 
-        const useXmlRpc = protocol === 'rsscloud-xml-rpc';
-        const rssCloudClient = createRssCloudClient({
-            serverUrl: serverOverride || config.hubServerUrl,
-            fetch
-        });
+        const useXmlRpc = protocol === 'xml-rpc';
+        const targetUrl = useXmlRpc ? rpcUrl : subscribeUrl;
+        const rssCloudClient = createRssCloudClient({ fetch });
         const subscribeParams = {
-            protocol: useXmlRpc ? 'xml-rpc' : 'http-post',
+            url: targetUrl,
+            protocol,
+            accept: useXmlRpc ? undefined : accepts,
             callback: {
                 domain: config.domain,
                 port: config.port,
@@ -505,183 +637,178 @@ function createApp({
                     ? `/s/${sessionId}/RPC2`
                     : `/s/${sessionId}/notify`
             },
-            feedUrl
+            feedUrl: settings.feedUrl
         };
-        await logAndRespond(
-            'pleaseNotify',
-            serverOverride || config.hubServerUrl,
+
+        logAndRespondAction(
+            sessionId,
+            res,
+            'rsscloud-subscribe',
+            targetUrl,
             subscribeParams,
             () => rssCloudClient.pleaseNotify(subscribeParams)
         );
     });
 
-    // Route: unified Unsubscribe action (WebSub only).
-    sessionRouter.post('/actions/unsubscribe', ensureSession, jsonParser, async(req, res) => {
+    // Route: rssCloud Ping — targets the RPC2 endpoint for xml-rpc, else the
+    // configured ping URL (which may be blank — the caller isn't testing
+    // ping — in which case there's nothing to call).
+    sessionRouter.post('/actions/rsscloud-ping', ensureSession, (req, res) => {
         const sessionId = req.params.sessionId;
-        const { server: serverOverride } = req.body;
-        const feedUrl = resolveFeedUrl(sessionId, req.body);
-        const logId = crypto.randomUUID();
+        const { settings } = req.session;
+        const { disabled, protocol, accepts, pingUrl, rpcUrl } = settings.rssCloud;
 
-        const hub = createWebSubClient({
-            serverUrl: serverOverride || config.hubServerUrl,
-            path: serverOverride ? '' : undefined,
-            fetch
-        });
-
-        broadcastOutgoingRequest(sessionId, {
-            id: logId,
-            timestamp: new Date().toISOString(),
-            method: 'POST',
-            url: serverOverride || hubUrl,
-            body: { action: 'websub-unsubscribe', topicUrl: feedUrl }
-        });
-
-        try {
-            const result = await hub.unsubscribe({
-                callbackUrl: webSubCallbackUrl(sessionId),
-                topicUrl: feedUrl
-            });
-            // Only drop the stored secret once the hub has actually
-            // acknowledged the unsubscribe — a failed call shouldn't lose it.
-            delete req.session.webSubSecrets[feedUrl];
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                ...result
-            });
-            res.json(result);
-        } catch (error) {
-            const message = describeActionError(error);
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                error: message
-            });
-            res.json({ error: message });
+        if (disabled) {
+            res.json({ error: 'rssCloud is disabled in settings' });
+            return;
         }
-    });
 
-    // Route: unified Publish action (WebSub only). Deliberately accepts only
-    // `feedName` — see the comment on /actions/ping for why.
-    sessionRouter.post('/actions/publish', ensureSession, jsonParser, async(req, res) => {
-        const sessionId = req.params.sessionId;
-        const { feedName = 'rss-01.xml', server: serverOverride } = req.body;
-        const feedUrl = `http://${config.domain}:${config.port}/s/${sessionId}/${feedName}`;
-        const logId = crypto.randomUUID();
-
-        if (!req.session.feedItems[feedName]) {
-            req.session.feedItems[feedName] = [
-                { title: 'initialized', timestamp: new Date() }
-            ];
+        const useXmlRpc = protocol === 'xml-rpc';
+        if (!useXmlRpc && !pingUrl) {
+            res.json({ error: 'no ping URL configured' });
+            return;
         }
-        const now = new Date();
-        req.session.feedItems[feedName].unshift({
-            title: `Update at ${now.toISOString()}`,
-            timestamp: now
-        });
 
-        const hub = createWebSubClient({
-            serverUrl: serverOverride || config.hubServerUrl,
-            path: serverOverride ? '' : undefined,
-            fetch
-        });
-
-        broadcastOutgoingRequest(sessionId, {
-            id: logId,
-            timestamp: new Date().toISOString(),
-            method: 'POST',
-            url: serverOverride || hubUrl,
-            body: { action: 'websub-publish', topicUrl: feedUrl }
-        });
-
-        try {
-            const result = await hub.publish({ topicUrl: feedUrl });
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                ...result
-            });
-            res.json(result);
-        } catch (error) {
-            const message = describeActionError(error);
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                error: message
-            });
-            res.json({ error: message });
-        }
-    });
-
-    // Route: unified Ping action. Deliberately accepts only `feedName` (never
-    // an arbitrary feedUrl) — this session can only ever ping/publish a feed
-    // it itself serves, never someone else's; that's the actual enforcement
-    // point for "don't ping/publish someone else's feed" (the UI hiding
-    // these controls in subscriber mode is a client-side mirror of this).
-    sessionRouter.post('/actions/ping', ensureSession, jsonParser, async(req, res) => {
-        const sessionId = req.params.sessionId;
-        const { protocol, feedName = 'rss-01.xml', server: serverOverride } =
-            req.body;
-        const feedUrl = `http://${config.domain}:${config.port}/s/${sessionId}/${feedName}`;
-        const logId = crypto.randomUUID();
-
-        if (!req.session.feedItems[feedName]) {
-            req.session.feedItems[feedName] = [
-                { title: 'initialized', timestamp: new Date() }
-            ];
-        }
-        const now = new Date();
-        req.session.feedItems[feedName].unshift({
-            title: `Update at ${now.toISOString()}`,
-            timestamp: now
-        });
-
-        const rssCloudClient = createRssCloudClient({
-            serverUrl: serverOverride || config.hubServerUrl,
-            fetch
-        });
+        const targetUrl = useXmlRpc ? rpcUrl : pingUrl;
+        const rssCloudClient = createRssCloudClient({ fetch });
         const pingParams = {
-            feedUrl,
-            transport: protocol === 'rsscloud-xml-rpc' ? 'xml-rpc' : 'rest'
+            url: targetUrl,
+            feedUrl: settings.feedUrl,
+            transport: useXmlRpc ? 'xml-rpc' : 'rest',
+            accept: useXmlRpc ? undefined : accepts
         };
 
-        broadcastOutgoingRequest(sessionId, {
-            id: logId,
-            timestamp: new Date().toISOString(),
-            method: 'POST',
-            url: serverOverride || config.hubServerUrl,
-            body: { action: 'ping', ...pingParams }
-        });
+        logAndRespondAction(
+            sessionId,
+            res,
+            'rsscloud-ping',
+            targetUrl,
+            pingParams,
+            () => rssCloudClient.ping(pingParams)
+        );
+    });
 
-        try {
-            const result = await rssCloudClient.ping(pingParams);
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                ...result
-            });
-            res.json(result);
-        } catch (error) {
-            const message = describeActionError(error);
-            broadcast(sessionId, {
-                id: logId,
-                direction: 'outgoing',
-                phase: 'response',
-                timestamp: new Date().toISOString(),
-                error: message
-            });
-            res.json({ error: message });
+    // Route: WebSub Subscribe — targets the session's configured hub URL.
+    sessionRouter.post('/actions/websub-subscribe', ensureSession, (req, res) => {
+        const sessionId = req.params.sessionId;
+        const { settings } = req.session;
+        const feedUrl = settings.feedUrl;
+
+        if (settings.webSub.disabled) {
+            res.json({ error: 'WebSub is disabled in settings' });
+            return;
         }
+
+        const { hubUrl: targetUrl, leaseSeconds, secret } = settings.webSub;
+        const hub = createWebSubClient({ serverUrl: targetUrl, path: '', fetch });
+
+        logAndRespondAction(
+            sessionId,
+            res,
+            'websub-subscribe',
+            targetUrl,
+            // Redact the secret in the logged/broadcast copy — it's still
+            // sent verbatim to the hub below, just never echoed into the log.
+            { topicUrl: feedUrl, leaseSeconds, secret: secret ? '(redacted)' : undefined },
+            () => hub.subscribe({
+                callbackUrl: webSubCallbackUrl(sessionId),
+                topicUrl: feedUrl,
+                leaseSeconds: leaseSeconds || undefined,
+                secret: secret || undefined
+            }),
+            () => {
+                if (secret) {
+                    req.session.webSubSecrets[feedUrl] = secret;
+                } else {
+                    delete req.session.webSubSecrets[feedUrl];
+                }
+            }
+        );
+    });
+
+    // Route: WebSub Unsubscribe — targets the session's configured hub URL.
+    sessionRouter.post('/actions/websub-unsubscribe', ensureSession, (req, res) => {
+        const sessionId = req.params.sessionId;
+        const { settings } = req.session;
+        const feedUrl = settings.feedUrl;
+
+        if (settings.webSub.disabled) {
+            res.json({ error: 'WebSub is disabled in settings' });
+            return;
+        }
+
+        const targetUrl = settings.webSub.hubUrl;
+        const hub = createWebSubClient({ serverUrl: targetUrl, path: '', fetch });
+
+        logAndRespondAction(
+            sessionId,
+            res,
+            'websub-unsubscribe',
+            targetUrl,
+            { topicUrl: feedUrl },
+            () => hub.unsubscribe({
+                callbackUrl: webSubCallbackUrl(sessionId),
+                topicUrl: feedUrl
+            }),
+            // Only drop the stored secret once the hub has actually
+            // acknowledged the unsubscribe — a failed call shouldn't lose it.
+            () => { delete req.session.webSubSecrets[feedUrl]; }
+        );
+    });
+
+    // Route: WebSub Publish — targets the session's configured hub URL. No
+    // longer touches feedItems (see Update Feed below) — Publish just
+    // notifies about whatever the feed currently holds.
+    sessionRouter.post('/actions/websub-publish', ensureSession, (req, res) => {
+        const sessionId = req.params.sessionId;
+        const { settings } = req.session;
+        const feedUrl = settings.feedUrl;
+
+        if (settings.webSub.disabled) {
+            res.json({ error: 'WebSub is disabled in settings' });
+            return;
+        }
+
+        const targetUrl = settings.webSub.hubUrl;
+        const hub = createWebSubClient({ serverUrl: targetUrl, path: '', fetch });
+
+        logAndRespondAction(
+            sessionId,
+            res,
+            'websub-publish',
+            targetUrl,
+            { topicUrl: feedUrl },
+            () => hub.publish({ topicUrl: feedUrl })
+        );
+    });
+
+    // Route: Update Feed — the only action that adds a new item to a
+    // self-hosted feed and bumps its "last updated" timestamp. Ping/Publish
+    // above just notify about whatever content is already there.
+    sessionRouter.post('/actions/update-feed', ensureSession, (req, res) => {
+        const sessionId = req.params.sessionId;
+        const { settings } = req.session;
+        const ctx = { domain: config.domain, port: config.port, sessionId };
+
+        if (!isSelfHostedFeedUrl(settings.feedUrl, ctx)) {
+            res.json({ error: 'feed is not self-hosted' });
+            return;
+        }
+
+        const feedName = feedNameFromSelfHostedUrl(settings.feedUrl, ctx);
+        if (!req.session.feedItems[feedName]) {
+            req.session.feedItems[feedName] = [
+                { title: 'initialized', timestamp: new Date() }
+            ];
+        }
+        const now = new Date();
+        req.session.feedItems[feedName].unshift({
+            title: `Update at ${now.toISOString()}`,
+            timestamp: now
+        });
+        req.session.feedLastUpdatedAt[feedName] = now;
+
+        res.json({ lastUpdatedAt: now });
     });
 
     // Route: WebSub intent verification — the hub GETs the callback with a
@@ -720,7 +847,10 @@ function createApp({
         res.type('text/xml').send(buildNotifyResponse());
     });
 
-    // Route: Serve RSS feeds (must be after specific routes)
+    // Route: Serve RSS feeds (must be after specific routes). The <cloud>/hub
+    // this session's own test feed advertises reflects its own settings, not
+    // the global default — so discovering your own test feed round-trips
+    // against whatever hub you're actually testing.
     sessionRouter.get('/:feedName', requireLiveSession, (req, res) => {
         const sessionId = req.params.sessionId;
         const feedName = req.params.feedName;
@@ -731,23 +861,19 @@ function createApp({
             return;
         }
 
+        const { settings } = req.session;
         const items = req.session.feedItems[feedName] || [
             { title: 'initialized', timestamp: new Date() }
         ];
         const feedUrl = `http://${config.domain}:${config.port}/s/${sessionId}/${feedName}`;
+        const hub = settings.webSub.disabled ? undefined : settings.webSub.hubUrl;
 
         const rssXml = renderCloudFeed({
             title: `Test Feed: ${feedName}`,
             link: feedUrl,
             description: 'Test feed for rssCloud',
-            cloud: {
-                domain: hubOrigin.hostname,
-                port: hubPort,
-                path: '/RPC2',
-                registerProcedure: 'rssCloud.pleaseNotify',
-                protocol: 'xml-rpc'
-            },
-            hub: hubUrl,
+            cloud: cloudFromSettings(settings.rssCloud),
+            hub,
             items: items.map((item, index) => ({
                 title: item.title,
                 description: `Feed item: ${item.title}`,
@@ -755,6 +881,11 @@ function createApp({
                 guid: `${feedName}-${index}`
             }))
         });
+        // Advertise the hub via the HTTP Link header too, not just the feed
+        // body — a real WebSub-supporting server typically does both.
+        if (hub) {
+            res.set('Link', `<${hub}>; rel="hub"`);
+        }
         res.type('application/rss+xml').send(rssXml);
     });
 

--- a/apps/debug/debug.test.js
+++ b/apps/debug/debug.test.js
@@ -830,6 +830,14 @@ test('GET /s/:id/settings renders a form prefilled with the session\'s current s
     assert.match(res.text, /value=['"]http:\/\/other-hub\.example\/pleaseNotify['"]/);
 });
 
+test('GET /s/:id/settings renders the WebSub secret field as a masked password input', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/mask-secret-session/settings');
+
+    assert.match(res.text, /<input(?=[^>]*id=['"]webSubSecret['"])(?=[^>]*type=['"]password['"])[^>]*>/);
+});
+
 test('GET /s/:id/settings renders an rssCloudDisabled checkbox reflecting the session\'s current settings', async() => {
     const sessionStore = createSessionStore();
     const app = createApp({ sessionStore });
@@ -1001,4 +1009,110 @@ test('POST /s/:id/settings sets rssCloud.disabled when the checkbox is present',
         });
 
     assert.equal(sessionStore.get(sessionId).settings.rssCloud.disabled, true);
+});
+
+test('POST /s/:id/settings rejects (without saving) a blank subscribeUrl when rssCloud is enabled over http-post', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-blank-subscribe-url-session';
+    await request(app).get(`/s/${sessionId}`);
+    const before = sessionStore.get(sessionId).settings;
+
+    const res = await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: `http://localhost:9000/s/${sessionId}/rss.xml`,
+            rssCloudProtocol: 'http-post',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: '',
+            rssCloudRpcUrl: 'http://localhost:5337/RPC2',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '',
+            webSubSecret: ''
+        });
+
+    assert.equal(res.status, 400);
+    // The rejected save must not overwrite the session's (still-valid) settings.
+    assert.deepEqual(sessionStore.get(sessionId).settings, before);
+
+    // ...and the feed route that would otherwise throw on a malformed URL
+    // keeps working, since the bad save never took effect.
+    const feedRes = await request(app).get(`/s/${sessionId}/rss.xml`);
+    assert.equal(feedRes.status, 200);
+});
+
+test('POST /s/:id/settings rejects a malformed rpcUrl when rssCloud is enabled over xml-rpc', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-malformed-rpc-url-session';
+    await request(app).get(`/s/${sessionId}`);
+
+    const res = await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: `http://localhost:9000/s/${sessionId}/rss.xml`,
+            rssCloudProtocol: 'xml-rpc',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: 'http://localhost:5337/pleaseNotify',
+            rssCloudRpcUrl: 'not-a-url',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '',
+            webSubSecret: ''
+        });
+
+    assert.equal(res.status, 400);
+});
+
+test('POST /s/:id/settings does not require a valid subscribeUrl when rssCloud is xml-rpc (only rpcUrl is used)', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-xmlrpc-ignores-subscribe-url-session';
+    await request(app).get(`/s/${sessionId}`);
+
+    const res = await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: `http://localhost:9000/s/${sessionId}/rss.xml`,
+            rssCloudProtocol: 'xml-rpc',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: '',
+            rssCloudRpcUrl: 'http://localhost:5337/RPC2',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '',
+            webSubSecret: ''
+        });
+
+    assert.equal(res.status, 302);
+    assert.equal(sessionStore.get(sessionId).settings.rssCloud.rpcUrl, 'http://localhost:5337/RPC2');
+});
+
+test('POST /s/:id/settings does not require a valid rssCloud URL when rssCloud is disabled', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-disabled-skips-validation-session';
+    await request(app).get(`/s/${sessionId}`);
+
+    const res = await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: `http://localhost:9000/s/${sessionId}/rss.xml`,
+            rssCloudDisabled: 'on',
+            rssCloudProtocol: 'http-post',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: '',
+            rssCloudRpcUrl: '',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '',
+            webSubSecret: ''
+        });
+
+    assert.equal(res.status, 302);
 });

--- a/apps/debug/debug.test.js
+++ b/apps/debug/debug.test.js
@@ -1,8 +1,55 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const http = require('node:http');
+const WebSocket = require('ws');
 const { createApp } = require('./debug');
 const { createSessionStore } = require('./lib/session-store');
 const request = require('supertest');
+
+function listen(server) {
+    return new Promise(resolve => {
+        server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+    });
+}
+
+function waitForOpen(ws) {
+    return new Promise((resolve, reject) => {
+        ws.once('open', resolve);
+        ws.once('error', reject);
+    });
+}
+
+async function waitUntil(predicate, timeoutMs = 2000) {
+    const start = Date.now();
+    while (!predicate()) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error('waitUntil timed out');
+        }
+        await new Promise(resolve => setTimeout(resolve, 5));
+    }
+}
+
+// The traffic log is purely live (no server-side storage) — to assert on
+// what an action broadcasts, connect a real WebSocket to the session's log
+// feed on a real listening server, same pattern as session-sockets.test.js.
+async function startTestServer(app) {
+    const server = http.createServer(app);
+    app.locals.attachSessionSockets(server);
+    const port = await listen(server);
+    return {
+        request: request(server),
+        async openLogSocket(sessionId) {
+            const ws = new WebSocket(`ws://127.0.0.1:${port}/s/${sessionId}/logs`);
+            const received = [];
+            ws.on('message', data => received.push(JSON.parse(data.toString())));
+            await waitForOpen(ws);
+            return { ws, received };
+        },
+        close() {
+            return new Promise(resolve => server.close(resolve));
+        }
+    };
+}
 
 test('GET /s/:id/notify 404s once the session has been idle past the callback threshold', async() => {
     let currentTime = 1000;
@@ -58,8 +105,8 @@ test('an outbound action refreshes the idle clock, keeping callback routes live'
 
     currentTime += 400;
     await request(app)
-        .post('/s/active-session/actions/ping')
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+        .post('/s/active-session/actions/rsscloud-ping')
+        .send({});
 
     // Past the threshold from session creation, but not from the ping above.
     currentTime += 400;
@@ -121,111 +168,219 @@ test('GET /s/:id embeds a socklog-viewer pointed at this session\'s WS log feed'
     );
 });
 
-test('GET /s/:id renders a unified protocol select and the session id on <body>', async() => {
+test('GET /s/:id renders the session id on <body> and a settings gear icon link', async() => {
     const app = createApp();
 
     const res = await request(app).get('/s/my-ui-session');
 
     assert.match(res.text, /<body[^>]*data-session-id=['"]my-ui-session['"]/);
-    assert.match(res.text, /<select[^>]*id=['"]protocol['"]/);
-    assert.match(res.text, /<option value=['"]rsscloud-rest['"]/);
-    assert.match(res.text, /<option value=['"]rsscloud-xml-rpc['"]/);
-    assert.match(res.text, /<option value=['"]websub['"]/);
+    assert.match(res.text, /<a[^>]*href=['"]\/s\/my-ui-session\/settings['"][^>]*>/);
 });
 
-test('POST /s/:id/actions/subscribe over rsscloud-rest calls pleaseNotify and returns JSON', async() => {
+test('GET /s/:id shows an Update Feed button and last-updated label for a self-hosted feed', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/self-hosted-session');
+
+    assert.match(res.text, /<button[^>]*id=['"]updateFeedButton['"]/);
+    assert.match(res.text, /Last updated/);
+});
+
+test('GET /s/:id shows the self-hosted feed\'s own URL alongside the Update Feed button', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/self-hosted-url-session');
+
+    assert.match(res.text, /http:\/\/localhost:9000\/s\/self-hosted-url-session\/rss\.xml/);
+});
+
+test('GET /s/:id shows the read-only feed URL, no Update Feed button, for a remote feed', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'remote-feed-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.feedUrl = 'https://example.com/feed.xml';
+
+    const res = await request(app).get(`/s/${sessionId}`);
+
+    assert.doesNotMatch(res.text, /id=['"]updateFeedButton['"]/);
+    assert.match(res.text, /https:\/\/example\.com\/feed\.xml/);
+});
+
+test('GET /s/:id omits the rssCloud row entirely when rssCloud is disabled', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-disabled-row-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.disabled = true;
+
+    const res = await request(app).get(`/s/${sessionId}`);
+
+    assert.doesNotMatch(res.text, /id=['"]rsscloudSubscribeButton['"]/);
+    assert.doesNotMatch(res.text, /id=['"]rsscloudPingButton['"]/);
+});
+
+test('GET /s/:id hides just the Ping button when rssCloud has a subscribe URL but no ping URL', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'no-ping-row-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.pingUrl = '';
+
+    const res = await request(app).get(`/s/${sessionId}`);
+
+    assert.match(res.text, /id=['"]rsscloudSubscribeButton['"]/);
+    assert.doesNotMatch(res.text, /id=['"]rsscloudPingButton['"]/);
+});
+
+test('GET /s/:id always shows Ping for xml-rpc, which has no separate ping URL concept', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'xmlrpc-ping-row-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.protocol = 'xml-rpc';
+
+    const res = await request(app).get(`/s/${sessionId}`);
+
+    assert.match(res.text, /id=['"]rsscloudPingButton['"]/);
+});
+
+test('GET /s/:id omits the WebSub row entirely when webSub is disabled', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'websub-disabled-row-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.webSub.disabled = true;
+
+    const res = await request(app).get(`/s/${sessionId}`);
+
+    assert.doesNotMatch(res.text, /id=['"]websubSubscribeButton['"]/);
+    assert.doesNotMatch(res.text, /id=['"]websubUnsubscribeButton['"]/);
+    assert.doesNotMatch(res.text, /id=['"]websubPublishButton['"]/);
+});
+
+test('GET /s/:id shows Subscribe/Unsubscribe/Publish when webSub is enabled', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/websub-enabled-row-session');
+
+    assert.match(res.text, /id=['"]websubSubscribeButton['"]/);
+    assert.match(res.text, /id=['"]websubUnsubscribeButton['"]/);
+    assert.match(res.text, /id=['"]websubPublishButton['"]/);
+});
+
+test('POST /s/:id/actions/rsscloud-subscribe over http-post calls pleaseNotify at the configured subscribe URL', async() => {
     const calls = [];
     const fetch = async(url, init) => {
         calls.push({ url: String(url), init });
         return { status: 200, text: async() => 'thanks' };
     };
-    const app = createApp({ fetch });
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'rsscloud-subscribe-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.subscribeUrl =
+        'http://other-hub.example/pleaseNotify';
 
     const res = await request(app)
-        .post('/s/my-session/actions/subscribe')
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+        .post(`/s/${sessionId}/actions/rsscloud-subscribe`)
+        .send({});
 
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, { status: 200, body: 'thanks' });
-    assert.equal(calls[0].url, 'http://localhost:5337/pleaseNotify');
+    assert.equal(calls[0].url, 'http://other-hub.example/pleaseNotify');
     const body = new URLSearchParams(calls[0].init.body);
     assert.equal(body.get('protocol'), 'http-post');
-    assert.equal(body.get('path'), '/s/my-session/notify');
+    assert.equal(body.get('path'), `/s/${sessionId}/notify`);
 });
 
-test('POST /s/:id/actions/subscribe over rsscloud-xml-rpc posts to /RPC2', async() => {
+test('POST /s/:id/actions/rsscloud-subscribe over xml-rpc posts to the configured RPC2 URL', async() => {
     const calls = [];
     const fetch = async(url, init) => {
         calls.push({ url: String(url), init });
         return { status: 200, text: async() => 'ok' };
     };
-    const app = createApp({ fetch });
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'rsscloud-subscribe-xmlrpc-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.protocol = 'xml-rpc';
+    sessionStore.get(sessionId).settings.rssCloud.rpcUrl =
+        'http://other-hub.example/RPC2';
 
     await request(app)
-        .post('/s/my-session/actions/subscribe')
-        .send({ protocol: 'rsscloud-xml-rpc', feedName: 'rss-01.xml' });
+        .post(`/s/${sessionId}/actions/rsscloud-subscribe`)
+        .send({});
 
-    assert.equal(calls[0].url, 'http://localhost:5337/RPC2');
+    assert.equal(calls[0].url, 'http://other-hub.example/RPC2');
 });
 
-test('POST /s/:id/actions/subscribe over websub posts hub.mode=subscribe to the hub', async() => {
+test('POST /s/:id/actions/rsscloud-subscribe errors without calling out when rssCloud is disabled', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 200, text: async() => 'ok' };
+    };
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'rsscloud-subscribe-disabled-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.disabled = true;
+
+    const res = await request(app)
+        .post(`/s/${sessionId}/actions/rsscloud-subscribe`)
+        .send({});
+
+    assert.ok(res.body.error);
+    assert.equal(calls.length, 0);
+});
+
+test('POST /s/:id/actions/websub-subscribe posts hub.mode=subscribe to the configured hub URL', async() => {
     const calls = [];
     const fetch = async(url, init) => {
         calls.push({ url: String(url), init });
         return { status: 202, text: async() => '' };
     };
-    const app = createApp({ fetch });
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'websub-subscribe-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.webSub.hubUrl =
+        'http://other-hub.example/custom-websub';
+    sessionStore.get(sessionId).settings.webSub.leaseSeconds = 3600;
 
     const res = await request(app)
-        .post('/s/my-session/actions/subscribe')
-        .send({ protocol: 'websub', feedName: 'rss-01.xml', leaseSeconds: 3600 });
+        .post(`/s/${sessionId}/actions/websub-subscribe`)
+        .send({});
 
     assert.equal(res.body.status, 202);
-    assert.equal(calls[0].url, 'http://localhost:5337/websub');
+    assert.equal(calls[0].url, 'http://other-hub.example/custom-websub');
     const body = new URLSearchParams(calls[0].init.body);
     assert.equal(body.get('hub.mode'), 'subscribe');
     assert.equal(body.get('hub.lease_seconds'), '3600');
 });
 
-test('POST /s/:id/actions/subscribe honors a server override for rssCloud', async() => {
-    const calls = [];
-    const fetch = async(url, init) => {
-        calls.push({ url: String(url), init });
-        return { status: 200, text: async() => 'ok' };
-    };
-    const app = createApp({ fetch });
-
-    await request(app)
-        .post('/s/my-session/actions/subscribe')
-        .send({
-            protocol: 'rsscloud-rest',
-            feedName: 'rss-01.xml',
-            server: 'http://other-hub.example'
-        });
-
-    assert.equal(calls[0].url, 'http://other-hub.example/pleaseNotify');
-});
-
-test('POST /s/:id/actions/subscribe honors a server override for websub (full hub URL, no double path)', async() => {
+test('POST /s/:id/actions/websub-subscribe errors without calling out when webSub is disabled', async() => {
     const calls = [];
     const fetch = async(url, init) => {
         calls.push({ url: String(url), init });
         return { status: 202, text: async() => '' };
     };
-    const app = createApp({ fetch });
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'websub-subscribe-disabled-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.webSub.disabled = true;
 
-    await request(app)
-        .post('/s/my-session/actions/subscribe')
-        .send({
-            protocol: 'websub',
-            feedName: 'rss-01.xml',
-            server: 'http://other-hub.example/custom-websub'
-        });
+    const res = await request(app)
+        .post(`/s/${sessionId}/actions/websub-subscribe`)
+        .send({});
 
-    assert.equal(calls[0].url, 'http://other-hub.example/custom-websub');
+    assert.ok(res.body.error);
+    assert.equal(calls.length, 0);
 });
 
-test('POST /s/:id/actions/ping calls ping and returns JSON', async() => {
+test('POST /s/:id/actions/rsscloud-ping calls ping at the configured ping URL and returns JSON', async() => {
     const calls = [];
     const fetch = async(url, init) => {
         calls.push({ url: String(url), init });
@@ -234,14 +389,14 @@ test('POST /s/:id/actions/ping calls ping and returns JSON', async() => {
     const app = createApp({ fetch });
 
     const res = await request(app)
-        .post('/s/my-session/actions/ping')
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+        .post('/s/my-session/actions/rsscloud-ping')
+        .send({});
 
     assert.deepEqual(res.body, { status: 200, body: 'pinged' });
     assert.equal(calls[0].url, 'http://localhost:5337/ping');
 });
 
-test('POST /s/:id/actions/ping surfaces the allowlist hint when the egress guard refuses the call', async() => {
+test('POST /s/:id/actions/rsscloud-ping surfaces the allowlist hint when the egress guard refuses the call', async() => {
     const fetch = async() => {
         throw Object.assign(
             new Error(
@@ -253,14 +408,34 @@ test('POST /s/:id/actions/ping surfaces the allowlist hint when the egress guard
     const app = createApp({ fetch });
 
     const res = await request(app)
-        .post('/s/my-session/actions/ping')
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+        .post('/s/my-session/actions/rsscloud-ping')
+        .send({});
 
     assert.ok(res.body.error.includes('loopback address'));
     assert.ok(res.body.error.includes('DEBUG_FETCH_ALLOW_CIDRS'));
 });
 
-test('POST /s/:id/actions/publish calls hub.mode=publish and returns JSON', async() => {
+test('POST /s/:id/actions/rsscloud-ping errors without calling out when there is no ping URL configured', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 200, text: async() => 'pinged' };
+    };
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch, sessionStore });
+    const sessionId = 'no-ping-url-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.pingUrl = '';
+
+    const res = await request(app)
+        .post(`/s/${sessionId}/actions/rsscloud-ping`)
+        .send({});
+
+    assert.ok(res.body.error);
+    assert.equal(calls.length, 0);
+});
+
+test('POST /s/:id/actions/websub-publish calls hub.mode=publish and returns JSON', async() => {
     const calls = [];
     const fetch = async(url, init) => {
         calls.push({ url: String(url), init });
@@ -269,8 +444,8 @@ test('POST /s/:id/actions/publish calls hub.mode=publish and returns JSON', asyn
     const app = createApp({ fetch });
 
     const res = await request(app)
-        .post('/s/my-session/actions/publish')
-        .send({ feedName: 'rss-01.xml' });
+        .post('/s/my-session/actions/websub-publish')
+        .send({});
 
     assert.equal(res.body.status, 202);
     assert.equal(calls[0].url, 'http://localhost:5337/websub');
@@ -278,7 +453,7 @@ test('POST /s/:id/actions/publish calls hub.mode=publish and returns JSON', asyn
     assert.equal(body.get('hub.mode'), 'publish');
 });
 
-test('POST /s/:id/actions/unsubscribe calls hub.mode=unsubscribe and returns JSON', async() => {
+test('POST /s/:id/actions/websub-unsubscribe calls hub.mode=unsubscribe and returns JSON', async() => {
     const calls = [];
     const fetch = async(url, init) => {
         calls.push({ url: String(url), init });
@@ -287,36 +462,59 @@ test('POST /s/:id/actions/unsubscribe calls hub.mode=unsubscribe and returns JSO
     const app = createApp({ fetch });
 
     const res = await request(app)
-        .post('/s/my-session/actions/unsubscribe')
-        .send({ feedName: 'rss-01.xml' });
+        .post('/s/my-session/actions/websub-unsubscribe')
+        .send({});
 
     assert.equal(res.body.status, 202);
     const body = new URLSearchParams(calls[0].init.body);
     assert.equal(body.get('hub.mode'), 'unsubscribe');
 });
 
-test('POST /s/:id/actions/discover fetches and reports what a feed advertises', async() => {
+test('POST /s/:id/actions/discover-settings fetches a feed and returns settings merged with what it advertises', async() => {
     const feedXml = `<?xml version="1.0"?>
 <rss version="2.0">
 <channel><title>t</title><link>http://feed.example/rss</link><description>d</description>
-<cloud domain="hub.example" port="80" path="/RPC2" registerProcedure="rssCloud.pleaseNotify" protocol="xml-rpc" />
+<cloud domain="hub.example" port="80" path="/pleaseNotify" registerProcedure="" protocol="http-post" />
 </channel></rss>`;
     const fetch = async() => ({ status: 200, text: async() => feedXml });
     const app = createApp({ fetch });
+    const currentSettings = {
+        feedUrl: 'http://feed.example/rss',
+        rssCloud: {
+            protocol: 'http-post',
+            accepts: 'xml',
+            pingUrl: 'http://localhost:5337/ping',
+            subscribeUrl: 'http://localhost:5337/pleaseNotify',
+            rpcUrl: 'http://localhost:5337/RPC2'
+        },
+        webSub: { disabled: false, hubUrl: 'http://localhost:5337/websub', leaseSeconds: '', secret: '' }
+    };
 
     const res = await request(app)
-        .post('/s/my-session/actions/discover')
-        .send({ feedUrl: 'http://feed.example/rss' });
+        .post('/s/my-session/actions/discover-settings')
+        .send({ feedUrl: 'http://feed.example/rss', currentSettings });
 
-    assert.equal(res.body.rssCloud.domain, 'hub.example');
-    assert.equal(res.body.webSub, null);
+    assert.equal(res.body.settings.rssCloud.subscribeUrl, 'http://hub.example:80/pleaseNotify');
+    assert.equal(res.body.settings.rssCloud.pingUrl, 'http://hub.example:80/ping');
+});
+
+test('POST /s/:id/actions/discover-settings reports an error instead of settings on a non-2xx fetch', async() => {
+    const fetch = async() => ({ status: 404, text: async() => 'Not Found' });
+    const app = createApp({ fetch });
+
+    const res = await request(app)
+        .post('/s/my-session/actions/discover-settings')
+        .send({ feedUrl: 'http://feed.example/missing.xml', currentSettings: {} });
+
+    assert.equal(res.body.settings, null);
+    assert.match(res.body.error, /404/);
 });
 
 function fakeFetch(status = 200, responseBody = 'OK') {
     return async() => ({ status, text: async() => responseBody });
 }
 
-test('pinging session A does not affect session B\'s same-named feed', async() => {
+test('updating session A\'s feed does not affect session B\'s same-named feed', async() => {
     const app = createApp({ fetch: fakeFetch() });
 
     // Visiting the UI is what creates a session; a feed/callback route on an
@@ -324,16 +522,102 @@ test('pinging session A does not affect session B\'s same-named feed', async() =
     await request(app).get('/s/session-a');
     await request(app).get('/s/session-b');
 
-    await request(app)
-        .post('/s/session-a/actions/ping')
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+    await request(app).post('/s/session-a/actions/update-feed').send({});
 
-    const feedA = await request(app).get('/s/session-a/rss-01.xml');
-    const feedB = await request(app).get('/s/session-b/rss-01.xml');
+    const feedA = await request(app).get('/s/session-a/rss.xml');
+    const feedB = await request(app).get('/s/session-b/rss.xml');
 
     assert.match(feedA.text, /Update at/);
     assert.doesNotMatch(feedB.text, /Update at/);
     assert.match(feedB.text, /initialized/);
+});
+
+test('rsscloud-ping does not add a feed item — it only notifies about existing content', async() => {
+    const app = createApp({ fetch: fakeFetch() });
+    const sessionId = 'ping-no-bump-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    await request(app).post(`/s/${sessionId}/actions/rsscloud-ping`).send({});
+
+    const feed = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.doesNotMatch(feed.text, /Update at/);
+    assert.match(feed.text, /initialized/);
+});
+
+test('websub-publish does not add a feed item — it only notifies about existing content', async() => {
+    const app = createApp({ fetch: fakeFetch(202, '') });
+    const sessionId = 'publish-no-bump-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    await request(app).post(`/s/${sessionId}/actions/websub-publish`).send({});
+
+    const feed = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.doesNotMatch(feed.text, /Update at/);
+    assert.match(feed.text, /initialized/);
+});
+
+test('GET /s/:id/rss.xml <cloud> element reflects this session\'s own rssCloud settings, not the global default', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'feed-cloud-override-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.subscribeUrl =
+        'http://other-hub.example:1234/pleaseNotify';
+
+    const res = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.match(res.text, /<cloud domain="other-hub\.example" port="1234" path="\/pleaseNotify"/);
+});
+
+test('GET /s/:id/rss.xml omits the <cloud> element when rssCloud is disabled in settings', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'feed-cloud-disabled-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.disabled = true;
+
+    const res = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.doesNotMatch(res.text, /<cloud/);
+});
+
+test('GET /s/:id/rss.xml omits the WebSub hub link when webSub is disabled in settings', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'feed-hub-disabled-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.webSub.disabled = true;
+
+    const res = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.doesNotMatch(res.text, /rel="hub"/);
+});
+
+test('GET /s/:id/rss.xml sets a Link response header advertising the hub', async() => {
+    const app = createApp();
+    const sessionId = 'feed-link-header-session';
+    await request(app).get(`/s/${sessionId}`);
+
+    const res = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.equal(res.headers.link, '<http://localhost:5337/websub>; rel="hub"');
+});
+
+test('GET /s/:id/rss.xml omits the Link response header when webSub is disabled', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'feed-link-header-disabled-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.webSub.disabled = true;
+
+    const res = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.equal(res.headers.link, undefined);
 });
 
 test('GET /s/:id/notify echoes the challenge query param', async() => {
@@ -352,8 +636,8 @@ test('without an injected fetch, an outbound call to the default (loopback) hub 
     const app = createApp();
 
     const res = await request(app)
-        .post('/s/my-session/actions/ping')
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+        .post('/s/my-session/actions/rsscloud-ping')
+        .send({});
 
     assert.equal(res.status, 200);
     // The guard rejects loopback; the response unwraps undici's "fetch failed"
@@ -366,61 +650,64 @@ test('subscribing logs an outgoing request entry and a paired response entry', a
     const sessionStore = createSessionStore();
     const app = createApp({ fetch: fakeFetch(200, 'thanks'), sessionStore });
     const sessionId = 'log-session';
+    const harness = await startTestServer(app);
+    await harness.request.get(`/s/${sessionId}`);
+    const { ws, received } = await harness.openLogSocket(sessionId);
 
-    await request(app)
-        .post(`/s/${sessionId}/actions/subscribe`)
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+    await harness.request.post(`/s/${sessionId}/actions/rsscloud-subscribe`).send({});
+    await waitUntil(() => received.length === 2);
 
-    const { requestLog } = sessionStore.get(sessionId);
-    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
-
-    assert.equal(outgoing.length, 2);
-    const [responseEntry, requestEntry] = outgoing; // newest-first
+    const [requestEntry, responseEntry] = received; // live order: request, then response
     assert.equal(requestEntry.phase, 'request');
     assert.equal(responseEntry.phase, 'response');
     assert.equal(responseEntry.id, requestEntry.id);
     assert.equal(responseEntry.status, 200);
     assert.equal(responseEntry.body, 'thanks');
+
+    ws.close();
+    await harness.close();
 });
 
 test('pinging logs an outgoing request entry and a paired response entry', async() => {
     const sessionStore = createSessionStore();
     const app = createApp({ fetch: fakeFetch(200, 'ok'), sessionStore });
     const sessionId = 'ping-log-session';
+    const harness = await startTestServer(app);
+    await harness.request.get(`/s/${sessionId}`);
+    const { ws, received } = await harness.openLogSocket(sessionId);
 
-    await request(app)
-        .post(`/s/${sessionId}/actions/ping`)
-        .send({ protocol: 'rsscloud-rest', feedName: 'rss-01.xml' });
+    await harness.request.post(`/s/${sessionId}/actions/rsscloud-ping`).send({});
+    await waitUntil(() => received.length === 2);
 
-    const { requestLog } = sessionStore.get(sessionId);
-    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
-
-    assert.equal(outgoing.length, 2);
-    const [responseEntry, requestEntry] = outgoing;
+    const [requestEntry, responseEntry] = received;
     assert.equal(requestEntry.phase, 'request');
     assert.equal(responseEntry.phase, 'response');
     assert.equal(responseEntry.id, requestEntry.id);
     assert.equal(responseEntry.status, 200);
+
+    ws.close();
+    await harness.close();
 });
 
 test('websub-subscribe logs an outgoing request entry and a paired response entry', async() => {
     const sessionStore = createSessionStore();
     const app = createApp({ fetch: fakeFetch(202, ''), sessionStore });
     const sessionId = 'websub-log-session';
+    const harness = await startTestServer(app);
+    await harness.request.get(`/s/${sessionId}`);
+    const { ws, received } = await harness.openLogSocket(sessionId);
 
-    await request(app)
-        .post(`/s/${sessionId}/actions/subscribe`)
-        .send({ protocol: 'websub', feedName: 'rss-01.xml' });
+    await harness.request.post(`/s/${sessionId}/actions/websub-subscribe`).send({});
+    await waitUntil(() => received.length === 2);
 
-    const { requestLog } = sessionStore.get(sessionId);
-    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
-
-    assert.equal(outgoing.length, 2);
-    const [responseEntry, requestEntry] = outgoing;
+    const [requestEntry, responseEntry] = received;
     assert.equal(requestEntry.phase, 'request');
     assert.equal(responseEntry.phase, 'response');
     assert.equal(responseEntry.id, requestEntry.id);
     assert.equal(responseEntry.status, 202);
+
+    ws.close();
+    await harness.close();
 });
 
 test('websub-subscribe redacts the secret in the logged request, but sends it verbatim to the hub', async() => {
@@ -432,19 +719,24 @@ test('websub-subscribe redacts the secret in the logged request, but sends it ve
     const sessionStore = createSessionStore();
     const app = createApp({ fetch, sessionStore });
     const sessionId = 'websub-secret-session';
+    const harness = await startTestServer(app);
+    await harness.request.get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.webSub.secret = 's3cr3t';
+    const { ws, received } = await harness.openLogSocket(sessionId);
 
-    await request(app)
-        .post(`/s/${sessionId}/actions/subscribe`)
-        .send({ protocol: 'websub', feedName: 'rss-01.xml', secret: 's3cr3t' });
+    await harness.request.post(`/s/${sessionId}/actions/websub-subscribe`).send({});
+    await waitUntil(() => received.length === 2);
 
-    const { requestLog } = sessionStore.get(sessionId);
-    const requestEntry = requestLog.find(
+    const requestEntry = received.find(
         e => e.direction === 'outgoing' && e.phase === 'request'
     );
     assert.notEqual(requestEntry.body.secret, 's3cr3t');
 
     const body = new URLSearchParams(calls[0].init.body);
     assert.equal(body.get('hub.secret'), 's3cr3t');
+
+    ws.close();
+    await harness.close();
 });
 
 test('a failed websub subscribe does not store the secret', async() => {
@@ -456,20 +748,20 @@ test('a failed websub subscribe does not store the secret', async() => {
     const sessionId = 'websub-failed-subscribe';
 
     await request(app).get(`/s/${sessionId}`);
-    const feedUrl = `http://localhost:9000/s/${sessionId}/rss-01.xml`;
+    const { settings } = sessionStore.get(sessionId);
+    settings.webSub.secret = 's3cr3t';
 
     await request(app)
-        .post(`/s/${sessionId}/actions/subscribe`)
-        .send({ protocol: 'websub', feedName: 'rss-01.xml', secret: 's3cr3t' });
+        .post(`/s/${sessionId}/actions/websub-subscribe`)
+        .send({});
 
-    assert.equal(sessionStore.get(sessionId).webSubSecrets[feedUrl], undefined);
+    assert.equal(sessionStore.get(sessionId).webSubSecrets[settings.feedUrl], undefined);
 });
 
 test('a failed websub unsubscribe does not clear a previously stored secret', async() => {
     const sessionStore = createSessionStore();
     const { id: sessionId, session } = sessionStore.createSession();
-    const feedUrl = `http://localhost:9000/s/${sessionId}/rss-01.xml`;
-    session.webSubSecrets[feedUrl] = 'existing-secret';
+    session.webSubSecrets[session.settings.feedUrl] = 'existing-secret';
 
     const fetch = async() => {
         throw new Error('network down');
@@ -477,46 +769,236 @@ test('a failed websub unsubscribe does not clear a previously stored secret', as
     const app = createApp({ fetch, sessionStore });
 
     await request(app)
-        .post(`/s/${sessionId}/actions/unsubscribe`)
-        .send({ feedName: 'rss-01.xml' });
+        .post(`/s/${sessionId}/actions/websub-unsubscribe`)
+        .send({});
 
-    assert.equal(session.webSubSecrets[feedUrl], 'existing-secret');
+    assert.equal(session.webSubSecrets[session.settings.feedUrl], 'existing-secret');
 });
 
 test('websub-unsubscribe logs an outgoing request entry and a paired response entry', async() => {
     const sessionStore = createSessionStore();
     const app = createApp({ fetch: fakeFetch(202, ''), sessionStore });
     const sessionId = 'websub-unsub-log-session';
+    const harness = await startTestServer(app);
+    await harness.request.get(`/s/${sessionId}`);
+    const { ws, received } = await harness.openLogSocket(sessionId);
 
-    await request(app)
-        .post(`/s/${sessionId}/actions/unsubscribe`)
-        .send({ feedName: 'rss-01.xml' });
+    await harness.request.post(`/s/${sessionId}/actions/websub-unsubscribe`).send({});
+    await waitUntil(() => received.length === 2);
 
-    const { requestLog } = sessionStore.get(sessionId);
-    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
-
-    assert.equal(outgoing.length, 2);
-    const [responseEntry, requestEntry] = outgoing;
+    const [requestEntry, responseEntry] = received;
     assert.equal(requestEntry.phase, 'request');
     assert.equal(responseEntry.phase, 'response');
     assert.equal(responseEntry.id, requestEntry.id);
+
+    ws.close();
+    await harness.close();
 });
 
 test('websub-publish logs an outgoing request entry and a paired response entry', async() => {
     const sessionStore = createSessionStore();
     const app = createApp({ fetch: fakeFetch(202, ''), sessionStore });
     const sessionId = 'websub-publish-log-session';
+    const harness = await startTestServer(app);
+    await harness.request.get(`/s/${sessionId}`);
+    const { ws, received } = await harness.openLogSocket(sessionId);
 
-    await request(app)
-        .post(`/s/${sessionId}/actions/publish`)
-        .send({ feedName: 'rss-01.xml' });
+    await harness.request.post(`/s/${sessionId}/actions/websub-publish`).send({});
+    await waitUntil(() => received.length === 2);
 
-    const { requestLog } = sessionStore.get(sessionId);
-    const outgoing = requestLog.filter(e => e.direction === 'outgoing');
-
-    assert.equal(outgoing.length, 2);
-    const [responseEntry, requestEntry] = outgoing;
+    const [requestEntry, responseEntry] = received;
     assert.equal(requestEntry.phase, 'request');
     assert.equal(responseEntry.phase, 'response');
     assert.equal(responseEntry.id, requestEntry.id);
+
+    ws.close();
+    await harness.close();
+});
+
+test('GET /s/:id/settings renders a form prefilled with the session\'s current settings', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'settings-page-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.subscribeUrl =
+        'http://other-hub.example/pleaseNotify';
+
+    const res = await request(app).get(`/s/${sessionId}/settings`);
+
+    assert.equal(res.status, 200);
+    assert.match(res.text, /<form[^>]*action=['"]\/s\/settings-page-session\/settings['"]/);
+    assert.match(res.text, /value=['"]http:\/\/other-hub\.example\/pleaseNotify['"]/);
+});
+
+test('GET /s/:id/settings renders an rssCloudDisabled checkbox reflecting the session\'s current settings', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-checkbox-render-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.disabled = true;
+
+    const res = await request(app).get(`/s/${sessionId}/settings`);
+
+    assert.match(res.text, /<input[^>]*id=['"]rssCloudDisabled['"][^>]*checked/);
+});
+
+test('GET /s/:id/settings\' Protocol select no longer offers a disabled option', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/no-disabled-option-session/settings');
+
+    assert.doesNotMatch(res.text, /<option value=['"]disabled['"]/);
+});
+
+test('GET /s/:id/settings embeds this session\'s self-hosted URL prefixes for the blur-discovery script', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/context-session/settings');
+
+    assert.match(res.text, /data-context=/);
+    assert.match(res.text, /http:\/\/localhost:9000\/s\/context-session\//);
+});
+
+test('GET /s/:id/settings embeds this session\'s computed default settings for the Reset button', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/default-settings-context-session/settings');
+
+    assert.match(res.text, /http:\/\/localhost:9000\/s\/default-settings-context-session\/rss\.xml/);
+    assert.match(res.text, /http:\/\/localhost:5337\/pleaseNotify/);
+});
+
+test('GET /s/:id/settings disables the Feed URL Reset button when the feed is still self-hosted', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/reset-disabled-session/settings');
+
+    assert.match(res.text, /<button[^>]*id=['"]feedUrlResetButton['"][^>]*disabled/);
+});
+
+test('GET /s/:id/settings enables the Feed URL Reset button when the feed has been changed to a remote URL', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'reset-enabled-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.feedUrl = 'https://example.com/feed.xml';
+
+    const res = await request(app).get(`/s/${sessionId}/settings`);
+
+    assert.doesNotMatch(res.text, /<button[^>]*id=['"]feedUrlResetButton['"][^>]*disabled/);
+});
+
+test('GET /s/:id/settings\' stylesheet forces [hidden] on the protocol-toggled fields, overriding style.css\'s explicit label/div display', async() => {
+    const app = createApp();
+
+    const res = await request(app).get('/s/hidden-css-session/settings');
+
+    assert.match(res.text, /\.rsscloud-rest-only\[hidden\][^{]*\{[^}]*display:\s*none/);
+    assert.match(res.text, /\.rsscloud-xmlrpc-only\[hidden\][^{]*\{[^}]*display:\s*none/);
+    assert.match(res.text, /\.websub-fields-body\[hidden\][^{]*\{[^}]*display:\s*none/);
+});
+
+test('POST /s/:id/settings persists the submitted form and redirects back to the main page', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'settings-save-session';
+    await request(app).get(`/s/${sessionId}`);
+
+    const res = await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: 'http://localhost:9000/s/settings-save-session/rss.xml',
+            rssCloudProtocol: 'xml-rpc',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: 'http://localhost:5337/pleaseNotify',
+            rssCloudRpcUrl: 'http://custom-hub.example/RPC2',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '3600',
+            webSubSecret: 's3cr3t'
+        });
+
+    assert.equal(res.status, 302);
+    assert.equal(res.headers.location, `/s/${sessionId}`);
+    const { settings } = sessionStore.get(sessionId);
+    assert.equal(settings.rssCloud.protocol, 'xml-rpc');
+    assert.equal(settings.rssCloud.rpcUrl, 'http://custom-hub.example/RPC2');
+    assert.equal(settings.webSub.leaseSeconds, '3600');
+    assert.equal(settings.webSub.secret, 's3cr3t');
+});
+
+test('POST /s/:id/settings treats an absent webSubDisabled checkbox as false', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'settings-checkbox-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.webSub.disabled = true;
+
+    await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: 'http://localhost:9000/s/settings-checkbox-session/rss.xml',
+            rssCloudProtocol: 'http-post',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: 'http://localhost:5337/pleaseNotify',
+            rssCloudRpcUrl: 'http://localhost:5337/RPC2',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '',
+            webSubSecret: ''
+        });
+
+    assert.equal(sessionStore.get(sessionId).settings.webSub.disabled, false);
+});
+
+test('POST /s/:id/settings treats an absent rssCloudDisabled checkbox as false', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-checkbox-absent-session';
+    await request(app).get(`/s/${sessionId}`);
+    sessionStore.get(sessionId).settings.rssCloud.disabled = true;
+
+    await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: 'http://localhost:9000/s/rsscloud-checkbox-absent-session/rss.xml',
+            rssCloudProtocol: 'http-post',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: 'http://localhost:5337/pleaseNotify',
+            rssCloudRpcUrl: 'http://localhost:5337/RPC2',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '',
+            webSubSecret: ''
+        });
+
+    assert.equal(sessionStore.get(sessionId).settings.rssCloud.disabled, false);
+});
+
+test('POST /s/:id/settings sets rssCloud.disabled when the checkbox is present', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ sessionStore });
+    const sessionId = 'rsscloud-checkbox-present-session';
+    await request(app).get(`/s/${sessionId}`);
+
+    await request(app)
+        .post(`/s/${sessionId}/settings`)
+        .type('form')
+        .send({
+            feedUrl: 'http://localhost:9000/s/rsscloud-checkbox-present-session/rss.xml',
+            rssCloudDisabled: 'on',
+            rssCloudProtocol: 'http-post',
+            rssCloudAccepts: 'xml',
+            rssCloudPingUrl: '',
+            rssCloudSubscribeUrl: 'http://localhost:5337/pleaseNotify',
+            rssCloudRpcUrl: 'http://localhost:5337/RPC2',
+            webSubHubUrl: 'http://localhost:5337/websub',
+            webSubLeaseSeconds: '',
+            webSubSecret: ''
+        });
+
+    assert.equal(sessionStore.get(sessionId).settings.rssCloud.disabled, true);
 });

--- a/apps/debug/lib/client.js
+++ b/apps/debug/lib/client.js
@@ -8,6 +8,11 @@ const { array, buildMethodCall, i4, str } = require('@rsscloud/xml-rpc');
 
 const FORM_TYPE = 'application/x-www-form-urlencoded';
 const XML_TYPE = 'text/xml';
+// The REST endpoints negotiate their response format via `req.accepts()`,
+// which resolves the 'xml' shorthand to this mime type (not the `text/xml`
+// XML-RPC Content-Type convention above) — sending `text/xml` here would
+// fail to match and get a 406.
+const XML_ACCEPT_TYPE = 'application/xml';
 
 // Build the rssCloud pleaseNotify methodCall — six positional params in wire
 // order: notifyProcedure, port, path, protocol, urlList, domain.
@@ -27,19 +32,32 @@ function buildPingCall(feedUrl) {
     return buildMethodCall('rssCloud.ping', [str(feedUrl)]);
 }
 
+// `accept` selects the Accept header for a REST call ('xml' | 'json'); the
+// outgoing body is always urlencoded regardless — only the requested reply
+// format varies. Absent, no Accept header override is sent.
+function acceptHeader(accept) {
+    if (!accept) {
+        return undefined;
+    }
+    return { Accept: accept === 'json' ? 'application/json' : XML_ACCEPT_TYPE };
+}
+
 // Build a client bound to one hub. pleaseNotify/ping pick their front door from
 // the request shape: an xml-rpc subscription and an xml-rpc ping go to /RPC2;
 // everything else uses the REST front doors. `callback.domain` is optional and
 // selects the hub's verification flow — given, the hub uses that host (with a
 // challenge for http-post/https-post); omitted, it uses the caller's address.
+// Every call accepts an explicit `url` to target instead of `serverUrl` +
+// its conventional suffix — `serverUrl` is only required when no call ever
+// passes one.
 function createRssCloudClient(options) {
     const doFetch = options.fetch ?? fetch;
-    const base = options.serverUrl.replace(/\/$/, '');
+    const base = options.serverUrl ? options.serverUrl.replace(/\/$/, '') : undefined;
 
-    async function send(path, contentType, body) {
-        const res = await doFetch(`${base}${path}`, {
+    async function send(url, contentType, body, extraHeaders) {
+        const res = await doFetch(url, {
             method: 'POST',
-            headers: { 'Content-Type': contentType },
+            headers: { 'Content-Type': contentType, ...extraHeaders },
             body
         });
         return { status: res.status, body: await res.text() };
@@ -48,7 +66,7 @@ function createRssCloudClient(options) {
     async function pleaseNotify(opts) {
         if (opts.protocol === 'xml-rpc') {
             return send(
-                '/RPC2',
+                opts.url ?? `${base}/RPC2`,
                 XML_TYPE,
                 buildPleaseNotifyCall({
                     notifyProcedure: 'rssCloud.notify',
@@ -69,17 +87,23 @@ function createRssCloudClient(options) {
         if (opts.callback.domain) {
             form.set('domain', opts.callback.domain);
         }
-        return send('/pleaseNotify', FORM_TYPE, form.toString());
+        return send(
+            opts.url ?? `${base}/pleaseNotify`,
+            FORM_TYPE,
+            form.toString(),
+            acceptHeader(opts.accept)
+        );
     }
 
     async function ping(opts) {
         if (opts.transport === 'xml-rpc') {
-            return send('/RPC2', XML_TYPE, buildPingCall(opts.feedUrl));
+            return send(opts.url ?? `${base}/RPC2`, XML_TYPE, buildPingCall(opts.feedUrl));
         }
         return send(
-            '/ping',
+            opts.url ?? `${base}/ping`,
             FORM_TYPE,
-            new URLSearchParams({ url: opts.feedUrl }).toString()
+            new URLSearchParams({ url: opts.feedUrl }).toString(),
+            acceptHeader(opts.accept)
         );
     }
 

--- a/apps/debug/lib/client.test.js
+++ b/apps/debug/lib/client.test.js
@@ -35,6 +35,21 @@ test('ping posts the feed URL to /ping by default', async() => {
     assert.deepEqual(res, { status: 200, body: 'OK' });
 });
 
+test('ping posts to an explicit url override instead of serverUrl + /ping', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.ping({
+        feedUrl: 'https://feed.example/rss',
+        url: 'http://other.example/custom-ping'
+    });
+
+    assert.equal(calls[0].url, 'http://other.example/custom-ping');
+});
+
 test('ping posts to /RPC2 over xml-rpc', async() => {
     const { fn, calls } = fakeFetch();
     const client = createRssCloudClient({
@@ -52,6 +67,42 @@ test('ping posts to /RPC2 over xml-rpc', async() => {
     const call = await parseMethodCall(calls[0].init.body);
     assert.equal(call.methodName, 'rssCloud.ping');
     assert.deepEqual(call.params, ['https://feed.example/rss']);
+});
+
+test('ping sets the Accept header to application/json when accept is json', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.ping({ feedUrl: 'https://feed.example/rss', accept: 'json' });
+
+    assert.equal(calls[0].init.headers.Accept, 'application/json');
+});
+
+test('ping sets the Accept header to application/xml when accept is xml (not text/xml — the server negotiates on the mime type, not the XML-RPC Content-Type convention)', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.ping({ feedUrl: 'https://feed.example/rss', accept: 'xml' });
+
+    assert.equal(calls[0].init.headers.Accept, 'application/xml');
+});
+
+test('ping sends no Accept override when accept is not given', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.ping({ feedUrl: 'https://feed.example/rss' });
+
+    assert.equal(calls[0].init.headers.Accept, undefined);
 });
 
 test('pleaseNotify over http-post sends the form with an explicit domain', async() => {
@@ -90,6 +141,23 @@ test('pleaseNotify over http-post omits domain when none is given', async() => {
     });
 
     assert.equal(form(calls[0].init).has('domain'), false);
+});
+
+test('pleaseNotify posts to an explicit url override instead of serverUrl + /pleaseNotify', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.pleaseNotify({
+        protocol: 'http-post',
+        callback: { port: 9000, path: '/notify' },
+        feedUrl: 'https://feed.example/rss',
+        url: 'http://other.example/custom-subscribe'
+    });
+
+    assert.equal(calls[0].url, 'http://other.example/custom-subscribe');
 });
 
 test('pleaseNotify over xml-rpc sends the six params', async() => {
@@ -145,6 +213,18 @@ test('strips a trailing slash from the server URL', async() => {
     await client.ping({ feedUrl: 'https://feed.example/rss' });
 
     assert.equal(calls[0].url, 'http://hub.example:5337/ping');
+});
+
+test('serverUrl is optional when every call passes an explicit url', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({ fetch: fn });
+
+    await client.ping({
+        feedUrl: 'https://feed.example/rss',
+        url: 'http://other.example/custom-ping'
+    });
+
+    assert.equal(calls[0].url, 'http://other.example/custom-ping');
 });
 
 test('defaults to the global fetch when none is injected', () => {

--- a/apps/debug/lib/client.test.js
+++ b/apps/debug/lib/client.test.js
@@ -160,6 +160,56 @@ test('pleaseNotify posts to an explicit url override instead of serverUrl + /ple
     assert.equal(calls[0].url, 'http://other.example/custom-subscribe');
 });
 
+test('pleaseNotify sets the Accept header to application/json when accept is json', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.pleaseNotify({
+        protocol: 'http-post',
+        callback: { port: 9000, path: '/notify' },
+        feedUrl: 'https://feed.example/rss',
+        accept: 'json'
+    });
+
+    assert.equal(calls[0].init.headers.Accept, 'application/json');
+});
+
+test('pleaseNotify sets the Accept header to application/xml when accept is xml', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.pleaseNotify({
+        protocol: 'http-post',
+        callback: { port: 9000, path: '/notify' },
+        feedUrl: 'https://feed.example/rss',
+        accept: 'xml'
+    });
+
+    assert.equal(calls[0].init.headers.Accept, 'application/xml');
+});
+
+test('pleaseNotify sends no Accept override when accept is not given', async() => {
+    const { fn, calls } = fakeFetch();
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn
+    });
+
+    await client.pleaseNotify({
+        protocol: 'http-post',
+        callback: { port: 9000, path: '/notify' },
+        feedUrl: 'https://feed.example/rss'
+    });
+
+    assert.equal(calls[0].init.headers.Accept, undefined);
+});
+
 test('pleaseNotify over xml-rpc sends the six params', async() => {
     const { fn, calls } = fakeFetch();
     const client = createRssCloudClient({

--- a/apps/debug/lib/discover.js
+++ b/apps/debug/lib/discover.js
@@ -13,9 +13,10 @@ function asArray(value) {
 }
 
 // Find a rel="<rel>" link among a channel/feed's <atom:link>/<link>
-// children, however xml2js happened to collapse them.
+// children, however xml2js happened to collapse them. RFC 8288 §3.3:
+// relation types SHOULD be treated case-insensitively.
 function findRelInBodyLinks(links, rel) {
-    return asArray(links).find(link => link?.$?.rel === rel)?.$?.href;
+    return asArray(links).find(link => link?.$?.rel?.toLowerCase() === rel.toLowerCase())?.$?.href;
 }
 
 const SOURCE_CLOUD_NS = 'https://source.scripting.com/';

--- a/apps/debug/lib/discover.js
+++ b/apps/debug/lib/discover.js
@@ -1,4 +1,6 @@
 const { Parser } = require('xml2js');
+const { URL } = require('url');
+const { parseLinkHeader, findLinkByRel } = require('./link-header');
 
 // xml2js (with explicitArray: false) collapses a lone matching child to a
 // bare object but promotes two-or-more to an array — normalize once here so
@@ -10,47 +12,113 @@ function asArray(value) {
     return Array.isArray(value) ? value : [value];
 }
 
-// Find a rel="hub" link among a channel/feed's <atom:link>/<link> children,
-// however xml2js happened to collapse them.
-function findHubLink(links) {
-    const hub = asArray(links).find(link => link?.$?.rel === 'hub');
-    return hub ? { hubUrl: hub.$.href } : null;
+// Find a rel="<rel>" link among a channel/feed's <atom:link>/<link>
+// children, however xml2js happened to collapse them.
+function findRelInBodyLinks(links, rel) {
+    return asArray(links).find(link => link?.$?.rel === rel)?.$?.href;
+}
+
+const SOURCE_CLOUD_NS = 'https://source.scripting.com/';
+const ATOM_NS = 'http://www.w3.org/2005/Atom';
+
+// xml2js (explicitArray: false) puts an element's attributes on `$`,
+// colon-and-all — so an `xmlns:x="..."` declaration shows up as `$['xmlns:x']`.
+function namespaceDeclarations(node) {
+    const attrs = node?.$ ?? {};
+    return Object.fromEntries(
+        Object.entries(attrs)
+            .filter(([key]) => key.startsWith('xmlns:'))
+            .map(([key, value]) => [key.slice('xmlns:'.length), value])
+    );
+}
+
+// Resolve whichever alias a document bound to `uri`, checking each candidate
+// node in declaration-search order (a binding can live on either the root
+// element or the channel). Returns undefined when the document never bound it.
+function resolveNamespacePrefix(uri, ...nodes) {
+    for (const node of nodes) {
+        const hit = Object.entries(namespaceDeclarations(node)).find(([, value]) => value === uri);
+        if (hit) {
+            return hit[0];
+        }
+    }
+    return undefined;
+}
+
+function parseCloudAttrs(attrs) {
+    if (!attrs) {
+        return null;
+    }
+    return {
+        domain: attrs.domain,
+        port: Number(attrs.port),
+        path: attrs.path,
+        registerProcedure: attrs.registerProcedure,
+        protocol: attrs.protocol
+    };
+}
+
+// Per https://source.scripting.com/ : <source:cloud> has no attributes —
+// its value is a plain URL, the scheme being the one extra bit of info
+// (http vs https) the original <cloud> element couldn't express. It's
+// meant to replace SOAP/XML-RPC outright, so it only ever resolves to
+// http-post/https-post — there's no way to spell "this is xml-rpc" here.
+function parseSourceCloudUrl(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    let url;
+    try {
+        url = new URL(value);
+    } catch {
+        return null;
+    }
+    return {
+        domain: url.hostname,
+        port: Number(url.port) || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname,
+        registerProcedure: '',
+        protocol: url.protocol === 'https:' ? 'https-post' : 'http-post'
+    };
 }
 
 // Detect what a feed advertises: an rssCloud <cloud> element, and/or a
 // WebSub hub link (`<atom:link rel="hub">` in RSS, `<link rel="hub">` in
 // Atom). Used by the harness's "enter a feed URL" discovery feature.
-async function parseFeedDiscovery(xmlText) {
+async function parseFeedDiscovery(xmlText, { linkHeader } = {}) {
     let parsed;
     try {
         parsed = await new Parser({ explicitArray: false }).parseStringPromise(
             xmlText
         );
     } catch {
-        return { rssCloud: null, webSub: null, error: 'not parseable as XML' };
+        return { rssCloud: null, webSub: null, selfUrl: undefined, error: 'not parseable as XML' };
     }
 
     const channel = parsed.rss?.channel;
-    const cloudAttrs = channel?.cloud?.$;
-    const rssCloud = cloudAttrs
-        ? {
-            domain: cloudAttrs.domain,
-            port: Number(cloudAttrs.port),
-            path: cloudAttrs.path,
-            registerProcedure: cloudAttrs.registerProcedure,
-            protocol: cloudAttrs.protocol
-        }
+
+    // A <source:cloud> (whatever prefix it's actually bound to) is canonical
+    // over a traditional <cloud> when a feed advertises both.
+    const traditionalCloud = parseCloudAttrs(channel?.cloud?.$);
+    const sourceCloudPrefix = resolveNamespacePrefix(SOURCE_CLOUD_NS, parsed.rss, channel);
+    const sourceCloud = sourceCloudPrefix
+        ? parseSourceCloudUrl(channel?.[`${sourceCloudPrefix}:cloud`])
         : null;
+    const rssCloud = sourceCloud ?? traditionalCloud ?? null;
 
-    // <cloud> only ever appears under an RSS channel; a hub link can appear
-    // there (`atom:link`) or under an Atom feed root (`link`). This assumes
-    // the RSS document uses the conventional `atom:` namespace prefix (as
-    // every real-world generator does) — a feed that binds the Atom
-    // namespace to a different alias would go undetected here.
-    const hubLinks = channel?.['atom:link'] ?? parsed.feed?.link;
-    const webSub = findHubLink(hubLinks);
+    // A hub/self link can appear under an RSS channel (conventionally
+    // `atom:link`) or under an Atom feed root (`link`). Resolve whatever
+    // alias the document actually bound to the Atom namespace, falling back
+    // to the ubiquitous `atom` convention when it's used without an explicit
+    // xmlns binding.
+    const atomPrefix = resolveNamespacePrefix(ATOM_NS, parsed.rss, channel) ?? 'atom';
+    const bodyLinks = channel?.[`${atomPrefix}:link`] ?? parsed.feed?.link;
+    const headerLinks = parseLinkHeader(linkHeader);
+    const hubUrl = findLinkByRel(headerLinks, 'hub') ?? findRelInBodyLinks(bodyLinks, 'hub');
+    const selfUrl = findLinkByRel(headerLinks, 'self') ?? findRelInBodyLinks(bodyLinks, 'self');
+    const webSub = hubUrl ? { hubUrl } : null;
 
-    return { rssCloud, webSub };
+    return { rssCloud, webSub, selfUrl };
 }
 
 // Fetch an arbitrary feed URL and report what protocols it advertises. A
@@ -62,10 +130,12 @@ async function discoverFeed({ url, fetch = globalThis.fetch }) {
         return {
             rssCloud: null,
             webSub: null,
+            selfUrl: undefined,
             error: `fetch failed: ${res.status}`
         };
     }
-    return parseFeedDiscovery(await res.text());
+    const linkHeader = typeof res.headers?.get === 'function' ? res.headers.get('link') : undefined;
+    return parseFeedDiscovery(await res.text(), { linkHeader });
 }
 
 module.exports = { parseFeedDiscovery, discoverFeed };

--- a/apps/debug/lib/discover.test.js
+++ b/apps/debug/lib/discover.test.js
@@ -38,6 +38,81 @@ test('detects the <cloud> element rendered by renderCloudFeed', async() => {
     assert.equal(result.webSub, null);
 });
 
+// Per https://source.scripting.com/ : <source:cloud> has no attributes —
+// its value is a plain URL, the one bit of extra information being the
+// scheme (http vs https). It can't represent xml-rpc (the whole point is to
+// replace SOAP/XML-RPC with a plain URL), so it always resolves to
+// http-post/https-post.
+const SOURCE_CLOUD_FEED = `<?xml version="1.0"?>
+<rss version="2.0" xmlns:source="https://source.scripting.com/">
+    <channel>
+        <title>Source Cloud Feed</title>
+        <link>http://sub.example:9000/rss-01.xml</link>
+        <description>Advertises source:cloud only</description>
+        <source:cloud>http://hub.example:5337/pleaseNotify</source:cloud>
+        <item><title>Entry one</title><guid>g0</guid></item>
+    </channel>
+</rss>`;
+
+test('detects a <source:cloud> element per the source.scripting.com namespace', async() => {
+    const result = await parseFeedDiscovery(SOURCE_CLOUD_FEED);
+
+    assert.deepEqual(result.rssCloud, {
+        domain: 'hub.example',
+        port: 5337,
+        path: '/pleaseNotify',
+        registerProcedure: '',
+        protocol: 'http-post'
+    });
+});
+
+const SOURCE_CLOUD_HTTPS_DEFAULT_PORT_FEED = `<?xml version="1.0"?>
+<rss version="2.0" xmlns:source="https://source.scripting.com/">
+    <channel>
+        <title>Source Cloud Feed (https, default port)</title>
+        <link>http://sub.example:9000/rss-01.xml</link>
+        <description>No explicit port in the URL — https implies 443</description>
+        <source:cloud>https://hub.example/pleaseNotify</source:cloud>
+        <item><title>Entry one</title><guid>g0</guid></item>
+    </channel>
+</rss>`;
+
+test('infers https-post and the default 443 port from a bare https:// source:cloud URL', async() => {
+    const result = await parseFeedDiscovery(SOURCE_CLOUD_HTTPS_DEFAULT_PORT_FEED);
+
+    assert.deepEqual(result.rssCloud, {
+        domain: 'hub.example',
+        port: 443,
+        path: '/pleaseNotify',
+        registerProcedure: '',
+        protocol: 'https-post'
+    });
+});
+
+const BOTH_CLOUD_KINDS_FEED = `<?xml version="1.0"?>
+<rss version="2.0" xmlns:src="https://source.scripting.com/">
+    <channel>
+        <title>Both Cloud Kinds</title>
+        <link>http://sub.example:9000/rss-01.xml</link>
+        <description>Advertises both cloud and source:cloud</description>
+        <cloud domain="old-hub.example" port="80" path="/pleaseNotify" registerProcedure="" protocol="http-post" />
+        <src:cloud>http://new-hub.example:5337/pleaseNotify</src:cloud>
+        <item><title>Entry one</title><guid>g0</guid></item>
+    </channel>
+</rss>`;
+
+test('prefers source:cloud (under any bound prefix) over a traditional <cloud> when both are present', async() => {
+    const result = await parseFeedDiscovery(BOTH_CLOUD_KINDS_FEED);
+
+    assert.deepEqual(result.rssCloud, {
+        domain: 'new-hub.example',
+        port: 5337,
+        path: '/pleaseNotify',
+        registerProcedure: '',
+        protocol: 'http-post'
+    });
+});
+
 test('detects both <cloud> and an atom:link rel=hub when a feed advertises both', async() => {
     const xml = sampleFeed({ hub: 'http://localhost:5337/websub' });
 
@@ -58,6 +133,40 @@ const ATOM_FEED = `<?xml version="1.0"?>
     </entry>
 </feed>`;
 
+const NONSTANDARD_ATOM_PREFIX_FEED = `<?xml version="1.0"?>
+<rss version="2.0" xmlns:a="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>Nonstandard Atom Prefix Feed</title>
+        <link>http://sub.example:9000/rss-01.xml</link>
+        <description>Hub link under a non-"atom" prefix bound to the Atom namespace</description>
+        <a:link rel="hub" href="http://hub.example/websub" />
+        <item><title>Entry one</title><guid>g0</guid></item>
+    </channel>
+</rss>`;
+
+test('detects a hub link under whichever prefix a feed actually bound to the Atom namespace', async() => {
+    const result = await parseFeedDiscovery(NONSTANDARD_ATOM_PREFIX_FEED);
+
+    assert.deepEqual(result.webSub, { hubUrl: 'http://hub.example/websub' });
+});
+
+const UNDECLARED_ATOM_PREFIX_FEED = `<?xml version="1.0"?>
+<rss version="2.0">
+    <channel>
+        <title>Undeclared Atom Prefix Feed</title>
+        <link>http://sub.example:9000/rss-01.xml</link>
+        <description>Uses atom:link by convention with no xmlns:atom declaration</description>
+        <atom:link rel="hub" href="http://hub.example/websub" />
+        <item><title>Entry one</title><guid>g0</guid></item>
+    </channel>
+</rss>`;
+
+test('falls back to the conventional atom: prefix when the namespace is not explicitly bound', async() => {
+    const result = await parseFeedDiscovery(UNDECLARED_ATOM_PREFIX_FEED);
+
+    assert.deepEqual(result.webSub, { hubUrl: 'http://hub.example/websub' });
+});
+
 test('detects a WebSub hub link in an Atom feed with no <cloud> element', async() => {
     const result = await parseFeedDiscovery(ATOM_FEED);
 
@@ -74,6 +183,30 @@ const PLAIN_RSS_FEED = `<?xml version="1.0"?>
         <item><title>Entry one</title><guid>g0</guid></item>
     </channel>
 </rss>`;
+
+test('prefers a Link header hub over a body-embedded hub link when both are present', async() => {
+    const xml = sampleFeed({ hub: 'http://body-hub.example/websub' });
+
+    const result = await parseFeedDiscovery(xml, {
+        linkHeader: '<http://header-hub.example/websub>; rel="hub"'
+    });
+
+    assert.deepEqual(result.webSub, { hubUrl: 'http://header-hub.example/websub' });
+});
+
+test('detects a rel=self link embedded in the feed body', async() => {
+    const result = await parseFeedDiscovery(ATOM_FEED);
+
+    assert.equal(result.selfUrl, 'http://sub.example:9000/atom.xml');
+});
+
+test('prefers a Link header self over a body-embedded self link when both are present', async() => {
+    const result = await parseFeedDiscovery(ATOM_FEED, {
+        linkHeader: '<http://header-self.example/atom.xml>; rel="self"'
+    });
+
+    assert.equal(result.selfUrl, 'http://header-self.example/atom.xml');
+});
 
 test('reports null for both when a feed advertises neither protocol', async() => {
     const result = await parseFeedDiscovery(PLAIN_RSS_FEED);
@@ -99,6 +232,29 @@ test('discoverFeed propagates a fetch rejection (e.g. an SSRF block) to the call
         () => discoverFeed({ url: 'http://blocked.example/rss', fetch }),
         /blocked/
     );
+});
+
+test('discoverFeed picks up a hub link from the response\'s Link header', async() => {
+    const fetch = async() => ({
+        status: 200,
+        headers: { get: name => (name === 'link' ? '<http://header-hub.example/websub>; rel="hub"' : null) },
+        text: async() => PLAIN_RSS_FEED
+    });
+
+    const result = await discoverFeed({ url: 'http://sub.example/plain.xml', fetch });
+
+    assert.deepEqual(result.webSub, { hubUrl: 'http://header-hub.example/websub' });
+});
+
+test('discoverFeed tolerates a fetch fixture with no headers.get (no Link header available)', async() => {
+    const fetch = async() => ({
+        status: 200,
+        text: async() => PLAIN_RSS_FEED
+    });
+
+    const result = await discoverFeed({ url: 'http://sub.example/plain.xml', fetch });
+
+    assert.equal(result.webSub, null);
 });
 
 test('discoverFeed short-circuits on a non-2xx response without parsing the body', async() => {

--- a/apps/debug/lib/discover.test.js
+++ b/apps/debug/lib/discover.test.js
@@ -150,6 +150,24 @@ test('detects a hub link under whichever prefix a feed actually bound to the Ato
     assert.deepEqual(result.webSub, { hubUrl: 'http://hub.example/websub' });
 });
 
+const MIXED_CASE_REL_FEED = `<?xml version="1.0"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>Mixed-case rel Feed</title>
+        <link>http://sub.example:9000/rss-01.xml</link>
+        <description>Uses rel="Hub" (mixed case)</description>
+        <atom:link rel="Hub" href="http://hub.example/websub" />
+        <item><title>Entry one</title><guid>g0</guid></item>
+    </channel>
+</rss>`;
+
+// RFC 8288 §3.3: relation types SHOULD be treated case-insensitively.
+test('detects a body-embedded hub link with a mixed-case rel value', async() => {
+    const result = await parseFeedDiscovery(MIXED_CASE_REL_FEED);
+
+    assert.deepEqual(result.webSub, { hubUrl: 'http://hub.example/websub' });
+});
+
 const UNDECLARED_ATOM_PREFIX_FEED = `<?xml version="1.0"?>
 <rss version="2.0">
     <channel>

--- a/apps/debug/lib/feed.js
+++ b/apps/debug/lib/feed.js
@@ -1,18 +1,39 @@
 const { Builder } = require('xml2js');
+const { URL } = require('url');
 
-// Render an RSS 2.0 feed carrying a <cloud> element — the document a publisher
-// serves so a hub knows where to register for change notifications. Item
-// pubDates are emitted in RFC 822 form. When `opts.hub` is given, the feed also
-// advertises a WebSub hub via <atom:link rel="hub"> (with a rel="self" pointing
-// at the feed's own URL), so the same document is discoverable over both
-// protocols.
+const SOURCE_CLOUD_NS = 'https://source.scripting.com/';
+
+// Per https://source.scripting.com/ : "The <source:cloud> element has no
+// attributes and its value is the URL of the cloud server" — a single URL,
+// whose scheme is the one extra bit of information (http vs https) the
+// original <cloud> element couldn't express. It's meant to replace
+// SOAP/XML-RPC outright, so there's no way to represent an xml-rpc endpoint
+// this way — callers should only pass an http-post/https-post cloud.
+function sourceCloudUrl(cloud) {
+    const scheme = cloud.protocol === 'https-post' ? 'https' : 'http';
+    return new URL(`${scheme}://${cloud.domain}:${cloud.port}${cloud.path}`).toString();
+}
+
+// Render an RSS 2.0 feed, optionally carrying a <cloud> element (plus its
+// <source:cloud> counterpart, the https://source.scripting.com/ convention,
+// for http-post/https-post clouds — it has no way to represent xml-rpc) —
+// the document a publisher serves so a hub knows where to register for
+// change notifications. Item pubDates are emitted in RFC 822 form. When
+// `opts.hub` is given, the feed also advertises a WebSub hub via
+// <atom:link rel="hub"> (with a rel="self" pointing at the feed's own URL),
+// so the same document is discoverable over both protocols. The
+// cloud/source:cloud/atom:link elements are placed before <item> so a
+// consumer sees discovery info without scanning past the entries.
 function renderCloudFeed(opts) {
     const rssAttrs = { version: '2.0' };
     const channel = {
         title: opts.title,
         link: opts.link,
-        description: opts.description,
-        cloud: {
+        description: opts.description
+    };
+
+    if (opts.cloud) {
+        channel.cloud = {
             $: {
                 domain: opts.cloud.domain,
                 port: String(opts.cloud.port),
@@ -20,14 +41,12 @@ function renderCloudFeed(opts) {
                 registerProcedure: opts.cloud.registerProcedure,
                 protocol: opts.cloud.protocol
             }
-        },
-        item: opts.items.map(item => ({
-            title: item.title,
-            description: item.description,
-            pubDate: item.pubDate.toUTCString(),
-            guid: item.guid
-        }))
-    };
+        };
+        if (opts.cloud.protocol !== 'xml-rpc') {
+            rssAttrs['xmlns:source'] = SOURCE_CLOUD_NS;
+            channel['source:cloud'] = sourceCloudUrl(opts.cloud);
+        }
+    }
 
     if (opts.hub) {
         rssAttrs['xmlns:atom'] = 'http://www.w3.org/2005/Atom';
@@ -36,6 +55,13 @@ function renderCloudFeed(opts) {
             { $: { rel: 'self', href: opts.link } }
         ];
     }
+
+    channel.item = opts.items.map(item => ({
+        title: item.title,
+        description: item.description,
+        pubDate: item.pubDate.toUTCString(),
+        guid: item.guid
+    }));
 
     return new Builder().buildObject({ rss: { $: rssAttrs, channel } });
 }

--- a/apps/debug/lib/feed.test.js
+++ b/apps/debug/lib/feed.test.js
@@ -98,6 +98,144 @@ test('omits the atom namespace and links when no hub is given', async() => {
     assert.equal(rss.channel['atom:link'], undefined);
 });
 
+const HTTP_CLOUD = {
+    domain: 'hub.example',
+    port: 5337,
+    path: '/pleaseNotify',
+    registerProcedure: '',
+    protocol: 'http-post'
+};
+
+test('places <cloud>, <source:cloud>, and <atom:link> before <item> in the channel', () => {
+    const xml = renderCloudFeed({
+        title: 'Test Feed',
+        link: 'http://sub.example:9000/rss-01.xml',
+        description: 'Test feed for rssCloud',
+        cloud: HTTP_CLOUD,
+        hub: 'http://localhost:5337/websub',
+        items: [
+            {
+                title: 'Update one',
+                description: 'first',
+                pubDate: new Date('2026-01-02T03:04:05Z'),
+                guid: 'rss-01-0'
+            }
+        ]
+    });
+
+    const itemIndex = xml.indexOf('<item>');
+    assert.ok(xml.indexOf('<cloud') < itemIndex);
+    assert.ok(xml.indexOf('<source:cloud') < itemIndex);
+    assert.ok(xml.indexOf('<atom:link') < itemIndex);
+});
+
+// Per https://source.scripting.com/ : "The <source:cloud> element has no
+// attributes and its value is the URL of the cloud server" — a plain URL,
+// not a mirror of <cloud>'s domain/port/path/protocol attributes.
+test('renders <source:cloud> as a plain URL (no attributes) for an http-post cloud', async() => {
+    const xml = renderCloudFeed({
+        title: 'Test Feed',
+        link: 'http://sub.example:9000/rss-01.xml',
+        description: 'Test feed for rssCloud',
+        cloud: HTTP_CLOUD,
+        items: [
+            {
+                title: 'Update one',
+                description: 'first',
+                pubDate: new Date('2026-01-02T03:04:05Z'),
+                guid: 'rss-01-0'
+            }
+        ]
+    });
+
+    const { rss } = await reparse(xml);
+    assert.equal(rss.$['xmlns:source'], 'https://source.scripting.com/');
+    assert.equal(rss.channel['source:cloud'], 'http://hub.example:5337/pleaseNotify');
+});
+
+test('renders <source:cloud> with an https:// URL for an https-post cloud, omitting the default 443 port', async() => {
+    const xml = renderCloudFeed({
+        title: 'Test Feed',
+        link: 'http://sub.example:9000/rss-01.xml',
+        description: 'Test feed for rssCloud',
+        cloud: { ...HTTP_CLOUD, port: 443, protocol: 'https-post' },
+        items: [
+            {
+                title: 'Update one',
+                description: 'first',
+                pubDate: new Date('2026-01-02T03:04:05Z'),
+                guid: 'rss-01-0'
+            }
+        ]
+    });
+
+    const { rss } = await reparse(xml);
+    assert.equal(rss.channel['source:cloud'], 'https://hub.example/pleaseNotify');
+});
+
+// source:cloud is meant to replace SOAP/XML-RPC entirely with a plain URL —
+// it has no way to express "this endpoint speaks XML-RPC," so omit it
+// rather than emit a URL a plain-HTTP consumer would misinterpret.
+test('omits <source:cloud> (and its namespace) for an xml-rpc cloud, which it cannot represent', async() => {
+    const xml = renderCloudFeed({
+        title: 'Test Feed',
+        link: 'http://sub.example:9000/rss-01.xml',
+        description: 'Test feed for rssCloud',
+        cloud: CLOUD,
+        items: [
+            {
+                title: 'Update one',
+                description: 'first',
+                pubDate: new Date('2026-01-02T03:04:05Z'),
+                guid: 'rss-01-0'
+            }
+        ]
+    });
+
+    const { rss } = await reparse(xml);
+    assert.equal(rss.channel['source:cloud'], undefined);
+    assert.equal(rss.$['xmlns:source'], undefined);
+});
+
+test('omits source:cloud and its namespace when no cloud is given', async() => {
+    const xml = renderCloudFeed({
+        title: 'Test Feed',
+        link: 'http://sub.example:9000/rss-01.xml',
+        description: 'Test feed for rssCloud',
+        items: [
+            {
+                title: 'Update one',
+                description: 'first',
+                pubDate: new Date('2026-01-02T03:04:05Z'),
+                guid: 'rss-01-0'
+            }
+        ]
+    });
+
+    const { rss } = await reparse(xml);
+    assert.equal(rss.channel['source:cloud'], undefined);
+    assert.equal(rss.$['xmlns:source'], undefined);
+});
+
+test('omits the <cloud> element entirely when no cloud is given', async() => {
+    const xml = renderCloudFeed({
+        title: 'Test Feed',
+        link: 'http://sub.example:9000/rss-01.xml',
+        description: 'Test feed for rssCloud',
+        items: [
+            {
+                title: 'Update one',
+                description: 'first',
+                pubDate: new Date('2026-01-02T03:04:05Z'),
+                guid: 'rss-01-0'
+            }
+        ]
+    });
+
+    const { rss } = await reparse(xml);
+    assert.equal(rss.channel.cloud, undefined);
+});
+
 test('renders multiple items in order', async() => {
     const xml = renderCloudFeed({
         title: 'Test Feed',

--- a/apps/debug/lib/link-header.js
+++ b/apps/debug/lib/link-header.js
@@ -1,0 +1,29 @@
+// RFC 8288-lite: only needs rel="hub"/rel="self", but handles multiple
+// comma-separated link-values per a real Link header. Splits only at a comma
+// immediately followed by '<' — the start of the next link-value — so a
+// comma inside a URL's own query string doesn't fracture it.
+function parseLinkHeader(value) {
+    if (!value) {
+        return [];
+    }
+    return value
+        .split(/,\s*(?=<)/)
+        .map(segment => {
+            const urlMatch = /<([^>]+)>/.exec(segment);
+            const relMatch = /rel=(?:"([^"]+)"|([^;,\s]+))/.exec(segment);
+            if (!urlMatch) {
+                return null;
+            }
+            return {
+                url: urlMatch[1].trim(),
+                rel: relMatch ? relMatch[1] ?? relMatch[2] : undefined
+            };
+        })
+        .filter(Boolean);
+}
+
+function findLinkByRel(links, rel) {
+    return links.find(link => link.rel === rel)?.url;
+}
+
+module.exports = { parseLinkHeader, findLinkByRel };

--- a/apps/debug/lib/link-header.js
+++ b/apps/debug/lib/link-header.js
@@ -22,8 +22,9 @@ function parseLinkHeader(value) {
         .filter(Boolean);
 }
 
+// RFC 8288 §3.3: relation types SHOULD be treated case-insensitively.
 function findLinkByRel(links, rel) {
-    return links.find(link => link.rel === rel)?.url;
+    return links.find(link => link.rel?.toLowerCase() === rel.toLowerCase())?.url;
 }
 
 module.exports = { parseLinkHeader, findLinkByRel };

--- a/apps/debug/lib/link-header.test.js
+++ b/apps/debug/lib/link-header.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseLinkHeader, findLinkByRel } = require('./link-header');
+
+test('parseLinkHeader parses a single link-value with a quoted rel', () => {
+    const links = parseLinkHeader('<https://hub.example/websub>; rel="hub"');
+
+    assert.deepEqual(links, [{ url: 'https://hub.example/websub', rel: 'hub' }]);
+});
+
+test('parseLinkHeader parses multiple comma-separated link-values', () => {
+    const links = parseLinkHeader(
+        '<https://hub.example/websub>; rel="hub", <https://feed.example/rss>; rel="self"'
+    );
+
+    assert.deepEqual(links, [
+        { url: 'https://hub.example/websub', rel: 'hub' },
+        { url: 'https://feed.example/rss', rel: 'self' }
+    ]);
+});
+
+test('parseLinkHeader accepts an unquoted (bare) rel value', () => {
+    const links = parseLinkHeader('<https://hub.example/websub>; rel=hub');
+
+    assert.deepEqual(links, [{ url: 'https://hub.example/websub', rel: 'hub' }]);
+});
+
+test('parseLinkHeader keeps a URL\'s own query-string comma intact', () => {
+    const links = parseLinkHeader(
+        '<https://hub.example/websub?a=1,2>; rel="hub"'
+    );
+
+    assert.deepEqual(links, [
+        { url: 'https://hub.example/websub?a=1,2', rel: 'hub' }
+    ]);
+});
+
+test('findLinkByRel returns undefined when no link matches the requested rel', () => {
+    const links = parseLinkHeader('<https://hub.example/websub>; rel="hub"');
+
+    assert.equal(findLinkByRel(links, 'self'), undefined);
+});
+
+test('parseLinkHeader returns an empty array for an empty or missing header', () => {
+    assert.deepEqual(parseLinkHeader(undefined), []);
+    assert.deepEqual(parseLinkHeader(''), []);
+});

--- a/apps/debug/lib/link-header.test.js
+++ b/apps/debug/lib/link-header.test.js
@@ -41,6 +41,13 @@ test('findLinkByRel returns undefined when no link matches the requested rel', (
     assert.equal(findLinkByRel(links, 'self'), undefined);
 });
 
+// RFC 8288 §3.3: relation types SHOULD be treated case-insensitively.
+test('findLinkByRel matches rel case-insensitively (e.g. rel="Hub")', () => {
+    const links = parseLinkHeader('<https://hub.example/websub>; rel="Hub"');
+
+    assert.equal(findLinkByRel(links, 'hub'), 'https://hub.example/websub');
+});
+
 test('parseLinkHeader returns an empty array for an empty or missing header', () => {
     assert.deepEqual(parseLinkHeader(undefined), []);
     assert.deepEqual(parseLinkHeader(''), []);

--- a/apps/debug/lib/session-store.js
+++ b/apps/debug/lib/session-store.js
@@ -1,24 +1,36 @@
 const { randomUUID } = require('crypto');
+const config = require('../config');
+const { computeDefaultSettings } = require('./settings');
 
-const MAX_LOG_ENTRIES = 100;
 // Absolute ceiling on how long a live socket alone can keep a session
 // exempt from idle/GC checks — long enough to cover "left a tab open over a
 // long weekend," but a hard backstop against an indefinitely-held
 // connection pinning a session in memory forever on a public deployment.
 const MAX_SESSION_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
-// Per-session in-memory state for the client harness: request log, served
-// feed items, and WebSub secrets, isolated per session id so concurrent
-// public users don't see each other's traffic.
-function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID } = {}) {
+// Per-session in-memory state for the client harness: served feed items and
+// WebSub secrets, isolated per session id so concurrent public users don't
+// see each other's traffic. The traffic log itself is never stored here —
+// it's a purely live broadcast (see session-sockets.js).
+function createSessionStore({
+    now = () => Date.now(),
+    idGenerator = randomUUID,
+    buildDefaultSettings = id => computeDefaultSettings({
+        sessionId: id,
+        domain: config.domain,
+        port: config.port,
+        hubServerUrl: config.hubServerUrl
+    })
+} = {}) {
     const sessions = new Map();
 
-    function newSession() {
+    function newSession(id) {
         const createdAt = now();
         return {
-            requestLog: [],
             feedItems: {},
+            feedLastUpdatedAt: {},
             webSubSecrets: {},
+            settings: buildDefaultSettings(id),
             sockets: new Set(),
             createdAt,
             lastOutgoingAt: createdAt
@@ -27,7 +39,7 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
 
     function createSession() {
         const id = idGenerator();
-        const session = newSession();
+        const session = newSession(id);
         sessions.set(id, session);
         return { id, session };
     }
@@ -38,7 +50,7 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
 
     function getOrCreate(id) {
         if (!sessions.has(id)) {
-            sessions.set(id, newSession());
+            sessions.set(id, newSession(id));
         }
         return sessions.get(id);
     }
@@ -94,20 +106,6 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
         return sessions.size;
     }
 
-    // Owns the request log's lifecycle (append + cap) so callers (the
-    // WebSocket layer, the incoming-request middleware) don't each
-    // reimplement the truncation policy.
-    function appendLog(id, entry) {
-        const session = sessions.get(id);
-        if (!session) {
-            return;
-        }
-        session.requestLog.unshift(entry);
-        if (session.requestLog.length > MAX_LOG_ENTRIES) {
-            session.requestLog.pop();
-        }
-    }
-
     return {
         createSession,
         get,
@@ -115,8 +113,7 @@ function createSessionStore({ now = () => Date.now(), idGenerator = randomUUID }
         touchOutgoing,
         isIdle,
         sweep,
-        size,
-        appendLog
+        size
     };
 }
 

--- a/apps/debug/lib/session-store.test.js
+++ b/apps/debug/lib/session-store.test.js
@@ -9,12 +9,36 @@ test('createSession mints a fresh session with the expected shape', () => {
 
     assert.equal(typeof id, 'string');
     assert.ok(id.length > 0);
-    assert.deepEqual(session.requestLog, []);
     assert.deepEqual(session.feedItems, {});
+    assert.deepEqual(session.feedLastUpdatedAt, {});
     assert.deepEqual(session.webSubSecrets, {});
     assert.equal(session.sockets.size, 0);
     assert.equal(session.createdAt, 1000);
     assert.equal(session.lastOutgoingAt, 1000);
+});
+
+test('createSession computes settings via the injected buildDefaultSettings, given the new session id', () => {
+    const seen = [];
+    const store = createSessionStore({
+        now: () => 1000,
+        buildDefaultSettings: id => {
+            seen.push(id);
+            return { feedUrl: `fake://${id}` };
+        }
+    });
+
+    const { id, session } = store.createSession();
+
+    assert.deepEqual(seen, [id]);
+    assert.deepEqual(session.settings, { feedUrl: `fake://${id}` });
+});
+
+test('createSession defaults settings from the real config when buildDefaultSettings is not injected', () => {
+    const store = createSessionStore({ now: () => 1000 });
+
+    const { id, session } = store.createSession();
+
+    assert.equal(session.settings.feedUrl, `http://localhost:9000/s/${id}/rss.xml`);
 });
 
 test('get returns the session created under an id, or undefined for an unknown id', () => {
@@ -149,35 +173,6 @@ test('sweep evicts a long-lived socket-holding session once it exceeds the absol
     assert.equal(evicted, 1);
     assert.equal(store.get(id), undefined);
     assert.equal(terminated, true);
-});
-
-test('appendLog unshifts an entry into the session\'s requestLog, newest-first', () => {
-    const store = createSessionStore({ now: () => 1000 });
-    const { id, session } = store.createSession();
-
-    store.appendLog(id, { id: '1' });
-    store.appendLog(id, { id: '2' });
-
-    assert.deepEqual(session.requestLog, [{ id: '2' }, { id: '1' }]);
-});
-
-test('appendLog is a safe no-op for an unknown id', () => {
-    const store = createSessionStore({ now: () => 1000 });
-
-    assert.doesNotThrow(() => store.appendLog('unknown-id', { id: '1' }));
-});
-
-test('appendLog caps the requestLog at 100 entries, dropping the oldest', () => {
-    const store = createSessionStore({ now: () => 1000 });
-    const { id, session } = store.createSession();
-
-    for (let i = 0; i < 101; i++) {
-        store.appendLog(id, { id: String(i) });
-    }
-
-    assert.equal(session.requestLog.length, 100);
-    assert.equal(session.requestLog[0].id, '100');
-    assert.equal(session.requestLog[99].id, '1');
 });
 
 test('size reflects the number of live sessions, including after a sweep', () => {

--- a/apps/debug/lib/settings.js
+++ b/apps/debug/lib/settings.js
@@ -1,0 +1,104 @@
+const SELF_HOSTED_FEED_NAME = 'rss.xml';
+
+function computeDefaultSettings({ sessionId, domain, port, hubServerUrl }) {
+    const hub = hubServerUrl.replace(/\/$/, '');
+    return {
+        feedUrl: `http://${domain}:${port}/s/${sessionId}/${SELF_HOSTED_FEED_NAME}`,
+        rssCloud: {
+            disabled: false,
+            protocol: 'http-post',
+            accepts: 'xml',
+            pingUrl: `${hub}/ping`,
+            subscribeUrl: `${hub}/pleaseNotify`,
+            rpcUrl: `${hub}/RPC2`
+        },
+        webSub: {
+            disabled: false,
+            hubUrl: `${hub}/websub`,
+            leaseSeconds: '',
+            secret: ''
+        }
+    };
+}
+
+function selfHostedPrefixes({ domain, port, sessionId }) {
+    return [
+        `http://${domain}:${port}/s/${sessionId}/`,
+        `https://${domain}:${port}/s/${sessionId}/`
+    ];
+}
+
+function feedNameFromSelfHostedUrl(feedUrl, ctx) {
+    const prefix = selfHostedPrefixes(ctx).find(p => feedUrl.startsWith(p));
+    return prefix ? feedUrl.slice(prefix.length) : null;
+}
+
+function isSelfHostedFeedUrl(feedUrl, ctx) {
+    return feedNameFromSelfHostedUrl(feedUrl, ctx) !== null;
+}
+
+const RECOGNIZED_RSSCLOUD_PROTOCOLS = ['http-post', 'https-post', 'xml-rpc'];
+
+// Mirrors packages/core/src/protocols/subscribe-request.ts's scheme rule —
+// not imported, since that module isn't part of @rsscloud/core's public
+// exports (this app already duplicates small cross-boundary helpers rather
+// than reaching into another package's internals).
+function schemeFor(protocol, port) {
+    return protocol === 'https-post' || String(port) === '443' ? 'https' : 'http';
+}
+
+function normalizePath(path) {
+    return path.startsWith('/') ? path : `/${path}`;
+}
+
+// Merge a discoverFeed() result into a settings snapshot. Only called after
+// a *successful* fetch+parse (the caller short-circuits to an error before
+// ever reaching here), so "not found" is a confident signal — this feed was
+// fully checked and genuinely doesn't advertise that protocol — not an
+// ambiguous "couldn't tell." Each group is enabled+configured when found,
+// disabled when not.
+function applyDiscoveryToSettings(settings, discovery) {
+    const next = {
+        feedUrl: settings.feedUrl,
+        rssCloud: { ...settings.rssCloud },
+        webSub: { ...settings.webSub }
+    };
+
+    if (discovery.rssCloud && RECOGNIZED_RSSCLOUD_PROTOCOLS.includes(discovery.rssCloud.protocol)) {
+        const { domain, port, path, protocol } = discovery.rssCloud;
+        const origin = `${schemeFor(protocol, port)}://${domain}:${port}`;
+        next.rssCloud.disabled = false;
+        next.rssCloud.protocol = protocol;
+        if (protocol === 'xml-rpc') {
+            next.rssCloud.rpcUrl = `${origin}${normalizePath(path)}`;
+        } else {
+            next.rssCloud.subscribeUrl = `${origin}${normalizePath(path)}`;
+            // A feed never carries a ping URL, only a registration endpoint —
+            // default ping to the discovered origin's conventional path.
+            next.rssCloud.pingUrl = `${origin}/ping`;
+        }
+    } else {
+        next.rssCloud.disabled = true;
+    }
+
+    if (discovery.webSub) {
+        next.webSub.disabled = false;
+        next.webSub.hubUrl = discovery.webSub.hubUrl;
+    } else {
+        next.webSub.disabled = true;
+    }
+
+    if (discovery.selfUrl) {
+        next.feedUrl = discovery.selfUrl;
+    }
+
+    return next;
+}
+
+module.exports = {
+    computeDefaultSettings,
+    selfHostedPrefixes,
+    feedNameFromSelfHostedUrl,
+    isSelfHostedFeedUrl,
+    applyDiscoveryToSettings
+};

--- a/apps/debug/lib/settings.test.js
+++ b/apps/debug/lib/settings.test.js
@@ -1,0 +1,239 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    computeDefaultSettings,
+    selfHostedPrefixes,
+    feedNameFromSelfHostedUrl,
+    isSelfHostedFeedUrl,
+    applyDiscoveryToSettings
+} = require('./settings');
+
+test('computeDefaultSettings builds the self-hosted feed URL from domain/port/session', () => {
+    const settings = computeDefaultSettings({
+        sessionId: 'abc-123',
+        domain: 'localhost',
+        port: 9000,
+        hubServerUrl: 'http://localhost:5337'
+    });
+
+    assert.equal(settings.feedUrl, 'http://localhost:9000/s/abc-123/rss.xml');
+});
+
+test('computeDefaultSettings defaults rssCloud to http-post against the configured hub', () => {
+    const settings = computeDefaultSettings({
+        sessionId: 'abc-123',
+        domain: 'localhost',
+        port: 9000,
+        hubServerUrl: 'http://localhost:5337'
+    });
+
+    assert.deepEqual(settings.rssCloud, {
+        disabled: false,
+        protocol: 'http-post',
+        accepts: 'xml',
+        pingUrl: 'http://localhost:5337/ping',
+        subscribeUrl: 'http://localhost:5337/pleaseNotify',
+        rpcUrl: 'http://localhost:5337/RPC2'
+    });
+});
+
+test('computeDefaultSettings defaults webSub to enabled with a blank lease/secret', () => {
+    const settings = computeDefaultSettings({
+        sessionId: 'abc-123',
+        domain: 'localhost',
+        port: 9000,
+        hubServerUrl: 'http://localhost:5337'
+    });
+
+    assert.deepEqual(settings.webSub, {
+        disabled: false,
+        hubUrl: 'http://localhost:5337/websub',
+        leaseSeconds: '',
+        secret: ''
+    });
+});
+
+test('computeDefaultSettings strips a trailing slash from the hub server URL', () => {
+    const settings = computeDefaultSettings({
+        sessionId: 'abc-123',
+        domain: 'localhost',
+        port: 9000,
+        hubServerUrl: 'http://localhost:5337/'
+    });
+
+    assert.equal(settings.rssCloud.pingUrl, 'http://localhost:5337/ping');
+});
+
+test('selfHostedPrefixes lists the http and https prefixes for this session', () => {
+    const prefixes = selfHostedPrefixes({
+        domain: 'localhost',
+        port: 9000,
+        sessionId: 'abc-123'
+    });
+
+    assert.deepEqual(prefixes, [
+        'http://localhost:9000/s/abc-123/',
+        'https://localhost:9000/s/abc-123/'
+    ]);
+});
+
+const ctx = { domain: 'localhost', port: 9000, sessionId: 'abc-123' };
+
+test('feedNameFromSelfHostedUrl extracts the feed name from a self-hosted URL', () => {
+    const name = feedNameFromSelfHostedUrl(
+        'http://localhost:9000/s/abc-123/rss.xml',
+        ctx
+    );
+
+    assert.equal(name, 'rss.xml');
+});
+
+test('feedNameFromSelfHostedUrl returns null for an external URL', () => {
+    const name = feedNameFromSelfHostedUrl(
+        'https://example.com/feed.xml',
+        ctx
+    );
+
+    assert.equal(name, null);
+});
+
+test('isSelfHostedFeedUrl is true for this session\'s own feed URL', () => {
+    assert.equal(
+        isSelfHostedFeedUrl('http://localhost:9000/s/abc-123/rss.xml', ctx),
+        true
+    );
+});
+
+test('isSelfHostedFeedUrl is false for an external feed URL', () => {
+    assert.equal(
+        isSelfHostedFeedUrl('https://example.com/feed.xml', ctx),
+        false
+    );
+});
+
+function baseSettings() {
+    return computeDefaultSettings({
+        sessionId: 'abc-123',
+        domain: 'localhost',
+        port: 9000,
+        hubServerUrl: 'http://localhost:5337'
+    });
+}
+
+test('applyDiscoveryToSettings updates the rssCloud group from a discovered http-post <cloud>', () => {
+    const next = applyDiscoveryToSettings(baseSettings(), {
+        rssCloud: {
+            domain: 'other-hub.example',
+            port: 80,
+            path: '/pleaseNotify',
+            registerProcedure: '',
+            protocol: 'http-post'
+        },
+        webSub: null
+    });
+
+    assert.equal(next.rssCloud.protocol, 'http-post');
+    assert.equal(next.rssCloud.subscribeUrl, 'http://other-hub.example:80/pleaseNotify');
+    assert.equal(next.rssCloud.pingUrl, 'http://other-hub.example:80/ping');
+});
+
+test('applyDiscoveryToSettings disables webSub when a feed advertises rssCloud but no WebSub hub', () => {
+    const next = applyDiscoveryToSettings(baseSettings(), {
+        rssCloud: {
+            domain: 'other-hub.example',
+            port: 80,
+            path: '/pleaseNotify',
+            registerProcedure: '',
+            protocol: 'http-post'
+        },
+        webSub: null
+    });
+
+    assert.equal(next.webSub.disabled, true);
+});
+
+test('applyDiscoveryToSettings re-enables a disabled rssCloud when discovery finds a recognized protocol', () => {
+    const settings = baseSettings();
+    settings.rssCloud.disabled = true;
+
+    const next = applyDiscoveryToSettings(settings, {
+        rssCloud: {
+            domain: 'other-hub.example',
+            port: 80,
+            path: '/pleaseNotify',
+            registerProcedure: '',
+            protocol: 'http-post'
+        },
+        webSub: null
+    });
+
+    assert.equal(next.rssCloud.disabled, false);
+});
+
+test('applyDiscoveryToSettings sets the single rpcUrl for a discovered xml-rpc <cloud>, not ping/subscribe', () => {
+    const next = applyDiscoveryToSettings(baseSettings(), {
+        rssCloud: {
+            domain: 'other-hub.example',
+            port: 5337,
+            path: '/RPC2',
+            registerProcedure: 'rssCloud.pleaseNotify',
+            protocol: 'xml-rpc'
+        },
+        webSub: null
+    });
+
+    assert.equal(next.rssCloud.protocol, 'xml-rpc');
+    assert.equal(next.rssCloud.rpcUrl, 'http://other-hub.example:5337/RPC2');
+});
+
+test('applyDiscoveryToSettings picks https when the discovered protocol is https-post', () => {
+    const next = applyDiscoveryToSettings(baseSettings(), {
+        rssCloud: {
+            domain: 'secure-hub.example',
+            port: 443,
+            path: '/pleaseNotify',
+            registerProcedure: '',
+            protocol: 'https-post'
+        },
+        webSub: null
+    });
+
+    assert.equal(next.rssCloud.subscribeUrl, 'https://secure-hub.example:443/pleaseNotify');
+    assert.equal(next.rssCloud.pingUrl, 'https://secure-hub.example:443/ping');
+});
+
+test('applyDiscoveryToSettings enables webSub and sets its hub URL from discovery', () => {
+    const settings = baseSettings();
+    settings.webSub.disabled = true;
+
+    const next = applyDiscoveryToSettings(settings, {
+        rssCloud: null,
+        webSub: { hubUrl: 'http://discovered-hub.example/websub' }
+    });
+
+    assert.equal(next.webSub.disabled, false);
+    assert.equal(next.webSub.hubUrl, 'http://discovered-hub.example/websub');
+});
+
+test('applyDiscoveryToSettings overrides feedUrl with a discovered rel=self canonical URL', () => {
+    const next = applyDiscoveryToSettings(baseSettings(), {
+        rssCloud: null,
+        webSub: null,
+        selfUrl: 'https://canonical.example/feed.xml'
+    });
+
+    assert.equal(next.feedUrl, 'https://canonical.example/feed.xml');
+});
+
+test('applyDiscoveryToSettings disables rssCloud and webSub when a successful discovery found neither', () => {
+    const settings = baseSettings();
+
+    const next = applyDiscoveryToSettings(settings, { rssCloud: null, webSub: null });
+
+    assert.equal(next.rssCloud.disabled, true);
+    assert.equal(next.webSub.disabled, true);
+    // Only the disabled flag flips — a feed's discovered URLs aren't erased
+    // just because a *different* re-discovery came back empty.
+    assert.equal(next.rssCloud.subscribeUrl, settings.rssCloud.subscribeUrl);
+    assert.equal(next.webSub.hubUrl, settings.webSub.hubUrl);
+});

--- a/apps/debug/public/app.js
+++ b/apps/debug/public/app.js
@@ -55,9 +55,16 @@ function bindAction(buttonId, action, onSuccess) {
         return;
     }
     button.addEventListener('click', async() => {
-        const result = await postAction(action);
-        if (!result.error) {
-            onSuccess?.(result);
+        // Disabled for the duration of the request — a rapid double-click
+        // would otherwise fire two overlapping calls against a real hub.
+        button.disabled = true;
+        try {
+            const result = await postAction(action);
+            if (!result.error) {
+                onSuccess?.(result);
+            }
+        } finally {
+            button.disabled = false;
         }
     });
 }

--- a/apps/debug/public/app.js
+++ b/apps/debug/public/app.js
@@ -1,18 +1,12 @@
-// Client-side wiring for the unified control box. No <form> submission
-// anywhere — every action is a button click that fetch()es a JSON action
-// endpoint; the outcome shows up as log entries in the live socklog viewer
-// instead of navigating to a result page.
+// Client-side wiring for the simplified control box. No <form> submission
+// for actions — every button click fetch()es a JSON action endpoint (which
+// reads its target entirely from the session's saved settings, not from
+// this request's body); the outcome shows up as log entries in the live
+// socklog viewer instead of navigating to a result page. Row/button
+// visibility is baked into the server-rendered markup (see debug.js's
+// renderPage), not toggled here.
 
 const sessionId = document.body.dataset.sessionId;
-
-const protocolSelect = document.getElementById('protocol');
-const feedUrlInput = document.getElementById('feedUrl');
-const feedNameInput = document.getElementById('feedName');
-const serverOverrideInput = document.getElementById('serverOverride');
-const leaseSecondsInput = document.getElementById('leaseSeconds');
-const secretInput = document.getElementById('secret');
-const pingButton = document.getElementById('pingButton');
-const publishButton = document.getElementById('publishButton');
 const actionError = document.getElementById('actionError');
 
 // Surface (or clear) a failed action prominently. A blocked/failed call is
@@ -27,23 +21,19 @@ function showActionError(message) {
     }
 }
 
-// The most recent successful discovery, so switching the protocol dropdown
-// can re-populate the override field without a second round trip.
-let lastDiscovery = null;
-
 // Never rejects — a network failure (can't reach the server at all) or a
 // non-JSON response (e.g. a proxy's error page) never reaches the server-side
 // broadcast that would otherwise show it in the traffic log, so this is the
 // one place that needs its own user-visible failure path. A returned `{ error }`
 // (e.g. the egress guard refusing the outbound call) is surfaced too, so a
 // blocked request never masquerades as success.
-async function postAction(action, fields) {
+async function postAction(action) {
     showActionError(null);
     try {
         const res = await fetch(`/s/${sessionId}/actions/${action}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(fields)
+            body: JSON.stringify({})
         });
         const result = await res.json();
         if (result && result.error) {
@@ -57,107 +47,29 @@ async function postAction(action, fields) {
     }
 }
 
-// Show only the controls relevant to the selected protocol. Never
-// hard-disables the others — forcing an undetected/unselected protocol is a
-// deliberate testing feature, not a bug.
-function updateProtocolVisibility() {
-    const isWebSub = protocolSelect.value === 'websub';
-    document.querySelectorAll('.websub-only').forEach(el => {
-        el.hidden = !isWebSub;
-    });
-    document.querySelectorAll('.rsscloud-only').forEach(el => {
-        el.hidden = isWebSub;
-    });
-    applyDiscoveryToOverride();
-}
-
-// Populate the override field from the last discovery, interpreted for
-// whichever protocol is currently selected.
-function applyDiscoveryToOverride() {
-    if (!lastDiscovery) {
+// A row's button is only rendered when its action is available (see
+// renderPage) — bindAction is a no-op for any button absent from this page.
+function bindAction(buttonId, action, onSuccess) {
+    const button = document.getElementById(buttonId);
+    if (!button) {
         return;
     }
-    if (protocolSelect.value === 'websub' && lastDiscovery.webSub) {
-        serverOverrideInput.value = lastDiscovery.webSub.hubUrl;
-    } else if (protocolSelect.value !== 'websub' && lastDiscovery.rssCloud) {
-        const { domain, port } = lastDiscovery.rssCloud;
-        serverOverrideInput.value = `http://${domain}:${port}`;
+    button.addEventListener('click', async() => {
+        const result = await postAction(action);
+        if (!result.error) {
+            onSuccess?.(result);
+        }
+    });
+}
+
+bindAction('rsscloudSubscribeButton', 'rsscloud-subscribe');
+bindAction('rsscloudPingButton', 'rsscloud-ping');
+bindAction('websubSubscribeButton', 'websub-subscribe');
+bindAction('websubUnsubscribeButton', 'websub-unsubscribe');
+bindAction('websubPublishButton', 'websub-publish');
+bindAction('updateFeedButton', 'update-feed', result => {
+    const label = document.getElementById('feedLastUpdated');
+    if (label && result.lastUpdatedAt) {
+        label.textContent = result.lastUpdatedAt;
     }
-}
-
-// Subscriber mode: an external feed URL means we're testing someone else's
-// feed, so we must never fake-publish or ping it. This mirrors the
-// server-side enforcement (the ping/publish actions only ever accept a
-// feedName, never a feedUrl) at the UI layer.
-function updateSubscriberMode() {
-    const isExternal = feedUrlInput.value.trim() !== '';
-    pingButton.disabled = isExternal;
-    publishButton.disabled = isExternal;
-}
-
-function currentFeedTarget() {
-    const feedUrl = feedUrlInput.value.trim();
-    return feedUrl ? { feedUrl } : { feedName: feedNameInput.value.trim() };
-}
-
-function currentServerOverride() {
-    const value = serverOverrideInput.value.trim();
-    return value ? { server: value } : {};
-}
-
-protocolSelect.addEventListener('change', updateProtocolVisibility);
-feedUrlInput.addEventListener('input', updateSubscriberMode);
-
-document.getElementById('discoverButton').addEventListener('click', async() => {
-    const feedUrl = feedUrlInput.value.trim();
-    if (!feedUrl) {
-        return;
-    }
-    const result = await postAction('discover', { feedUrl });
-    lastDiscovery = result;
-    if (result.rssCloud && result.rssCloud.protocol === 'xml-rpc') {
-        protocolSelect.value = 'rsscloud-xml-rpc';
-    } else if (result.rssCloud) {
-        protocolSelect.value = 'rsscloud-rest';
-    } else if (result.webSub) {
-        protocolSelect.value = 'websub';
-    }
-    updateProtocolVisibility();
 });
-
-document.getElementById('subscribeButton').addEventListener('click', () => {
-    postAction('subscribe', {
-        protocol: protocolSelect.value,
-        leaseSeconds: leaseSecondsInput.value
-            ? parseInt(leaseSecondsInput.value, 10)
-            : undefined,
-        secret: secretInput.value || undefined,
-        ...currentFeedTarget(),
-        ...currentServerOverride()
-    });
-});
-
-document.getElementById('unsubscribeButton').addEventListener('click', () => {
-    postAction('unsubscribe', {
-        ...currentFeedTarget(),
-        ...currentServerOverride()
-    });
-});
-
-pingButton.addEventListener('click', () => {
-    postAction('ping', {
-        protocol: protocolSelect.value,
-        feedName: feedNameInput.value.trim(),
-        ...currentServerOverride()
-    });
-});
-
-publishButton.addEventListener('click', () => {
-    postAction('publish', {
-        feedName: feedNameInput.value.trim(),
-        ...currentServerOverride()
-    });
-});
-
-updateProtocolVisibility();
-updateSubscriberMode();

--- a/apps/debug/public/settings.js
+++ b/apps/debug/public/settings.js
@@ -141,11 +141,17 @@ function writeFormSettings(settings) {
     updateWebSubVisibility();
 }
 
+// Guards against a stale response landing after a newer blur's — e.g. if
+// the user edits and blurs again before the first request comes back,
+// only the result matching the latest request may write the form.
+let latestDiscoveryRequestId = 0;
+
 feedUrlInput.addEventListener('blur', async() => {
     const feedUrl = feedUrlInput.value.trim();
     if (!feedUrl || isSelfHosted(feedUrl)) {
         return;
     }
+    const requestId = ++latestDiscoveryRequestId;
     showActionError(null);
     try {
         const res = await fetch(`/s/${sessionId}/actions/discover-settings`, {
@@ -154,12 +160,18 @@ feedUrlInput.addEventListener('blur', async() => {
             body: JSON.stringify({ feedUrl, currentSettings: readFormSettings() })
         });
         const result = await res.json();
+        if (requestId !== latestDiscoveryRequestId) {
+            return;
+        }
         if (result.error) {
             showActionError(`discover failed: ${result.error}`);
             return;
         }
         writeFormSettings(result.settings);
     } catch (error) {
+        if (requestId !== latestDiscoveryRequestId) {
+            return;
+        }
         showActionError(`discover failed: ${error.message}`);
     }
 });

--- a/apps/debug/public/settings.js
+++ b/apps/debug/public/settings.js
@@ -1,0 +1,170 @@
+// Client-side wiring for the settings form: protocol/checkbox-driven field
+// visibility, and Feed-URL-blur-triggered discovery to prefill the rest of
+// the form from an external feed's advertised rssCloud/WebSub config. Save
+// itself needs no JS — it's a plain <form> submit that navigates the browser
+// back to the main page on success.
+
+const form = document.querySelector('form');
+const context = JSON.parse(form.dataset.context);
+const sessionId = location.pathname.split('/')[2];
+
+const feedUrlInput = document.getElementById('feedUrl');
+const feedUrlResetButton = document.getElementById('feedUrlResetButton');
+const rssCloudDisabledCheckbox = document.getElementById('rssCloudDisabled');
+const rssCloudFieldsBody = document.querySelector('.rsscloud-fields-body');
+const protocolSelect = document.getElementById('rssCloudProtocol');
+const acceptsSelect = document.getElementById('rssCloudAccepts');
+const pingUrlInput = document.getElementById('rssCloudPingUrl');
+const subscribeUrlInput = document.getElementById('rssCloudSubscribeUrl');
+const rpcUrlInput = document.getElementById('rssCloudRpcUrl');
+const webSubDisabledCheckbox = document.getElementById('webSubDisabled');
+const webSubFieldsBody = document.querySelector('.websub-fields-body');
+const hubUrlInput = document.getElementById('webSubHubUrl');
+const leaseSecondsInput = document.getElementById('webSubLeaseSeconds');
+const secretInput = document.getElementById('webSubSecret');
+const actionError = document.getElementById('actionError');
+
+function showActionError(message) {
+    if (message) {
+        actionError.textContent = message;
+        actionError.hidden = false;
+    } else {
+        actionError.textContent = '';
+        actionError.hidden = true;
+    }
+}
+
+function updateProtocolVisibility() {
+    const protocol = protocolSelect.value;
+    const isRest = protocol === 'http-post' || protocol === 'https-post';
+    document.querySelectorAll('.rsscloud-rest-only').forEach(el => {
+        el.hidden = !isRest;
+    });
+    document.querySelectorAll('.rsscloud-xmlrpc-only').forEach(el => {
+        el.hidden = protocol !== 'xml-rpc';
+    });
+}
+
+// Switching between http-post/https-post implies a scheme — keep the ping
+// and subscribe URLs in sync with it (rewriting only the scheme, so a
+// custom host/port/path you've typed keeps its shape). No-op for xml-rpc,
+// where the RPC2 URL's scheme is independent of the protocol dropdown.
+function syncRestUrlSchemes() {
+    const protocol = protocolSelect.value;
+    if (protocol !== 'http-post' && protocol !== 'https-post') {
+        return;
+    }
+    const scheme = protocol === 'https-post' ? 'https:' : 'http:';
+    for (const input of [pingUrlInput, subscribeUrlInput]) {
+        const value = input.value.trim();
+        if (!value) {
+            continue;
+        }
+        try {
+            const url = new URL(value);
+            url.protocol = scheme;
+            input.value = url.toString();
+        } catch {
+            // Not a valid absolute URL yet — leave it for the user to fix.
+        }
+    }
+}
+
+function updateRssCloudVisibility() {
+    rssCloudFieldsBody.hidden = rssCloudDisabledCheckbox.checked;
+}
+
+function updateWebSubVisibility() {
+    webSubFieldsBody.hidden = webSubDisabledCheckbox.checked;
+}
+
+protocolSelect.addEventListener('change', () => {
+    syncRestUrlSchemes();
+    updateProtocolVisibility();
+});
+rssCloudDisabledCheckbox.addEventListener('change', updateRssCloudVisibility);
+webSubDisabledCheckbox.addEventListener('change', updateWebSubVisibility);
+
+// this session's own feed (any path under it) vs. an external one worth
+// discovering.
+function isSelfHosted(url) {
+    return context.selfHostedPrefixes.some(prefix => url.startsWith(prefix));
+}
+
+// Reset only makes sense once you've pointed Feed URL at something other
+// than this session's own feed — disabled the rest of the time.
+function updateFeedUrlResetButton() {
+    feedUrlResetButton.disabled = isSelfHosted(feedUrlInput.value.trim());
+}
+
+feedUrlInput.addEventListener('input', updateFeedUrlResetButton);
+feedUrlResetButton.addEventListener('click', () => {
+    showActionError(null);
+    writeFormSettings(context.defaultSettings);
+});
+
+function readFormSettings() {
+    return {
+        feedUrl: feedUrlInput.value.trim(),
+        rssCloud: {
+            disabled: rssCloudDisabledCheckbox.checked,
+            protocol: protocolSelect.value,
+            accepts: acceptsSelect.value,
+            pingUrl: pingUrlInput.value.trim(),
+            subscribeUrl: subscribeUrlInput.value.trim(),
+            rpcUrl: rpcUrlInput.value.trim()
+        },
+        webSub: {
+            disabled: webSubDisabledCheckbox.checked,
+            hubUrl: hubUrlInput.value.trim(),
+            leaseSeconds: leaseSecondsInput.value.trim(),
+            secret: secretInput.value.trim()
+        }
+    };
+}
+
+function writeFormSettings(settings) {
+    feedUrlInput.value = settings.feedUrl;
+    rssCloudDisabledCheckbox.checked = settings.rssCloud.disabled;
+    protocolSelect.value = settings.rssCloud.protocol;
+    acceptsSelect.value = settings.rssCloud.accepts;
+    pingUrlInput.value = settings.rssCloud.pingUrl;
+    subscribeUrlInput.value = settings.rssCloud.subscribeUrl;
+    rpcUrlInput.value = settings.rssCloud.rpcUrl;
+    webSubDisabledCheckbox.checked = settings.webSub.disabled;
+    hubUrlInput.value = settings.webSub.hubUrl;
+    leaseSecondsInput.value = settings.webSub.leaseSeconds;
+    secretInput.value = settings.webSub.secret;
+    updateFeedUrlResetButton();
+    updateRssCloudVisibility();
+    updateProtocolVisibility();
+    updateWebSubVisibility();
+}
+
+feedUrlInput.addEventListener('blur', async() => {
+    const feedUrl = feedUrlInput.value.trim();
+    if (!feedUrl || isSelfHosted(feedUrl)) {
+        return;
+    }
+    showActionError(null);
+    try {
+        const res = await fetch(`/s/${sessionId}/actions/discover-settings`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ feedUrl, currentSettings: readFormSettings() })
+        });
+        const result = await res.json();
+        if (result.error) {
+            showActionError(`discover failed: ${result.error}`);
+            return;
+        }
+        writeFormSettings(result.settings);
+    } catch (error) {
+        showActionError(`discover failed: ${error.message}`);
+    }
+});
+
+updateFeedUrlResetButton();
+updateRssCloudVisibility();
+updateProtocolVisibility();
+updateWebSubVisibility();

--- a/apps/debug/session-sockets.js
+++ b/apps/debug/session-sockets.js
@@ -25,23 +25,18 @@ function createSessionSockets({ sessionStore }) {
 
             wss.handleUpgrade(request, socket, head, ws => {
                 session.sockets.add(ws);
-                // Backfill a late-connecting viewer with this session's
-                // history, oldest-first (requestLog itself is newest-first).
-                for (const entry of session.requestLog.slice().reverse()) {
-                    ws.send(JSON.stringify(entry));
-                }
                 ws.on('close', () => session.sockets.delete(ws));
             });
         });
     }
 
+    // Purely live — nothing is stored server-side, so a socket connecting
+    // late only sees whatever happens after it connects.
     function broadcast(sessionId, entry) {
         const session = sessionStore.get(sessionId);
         if (!session) {
             return;
         }
-
-        sessionStore.appendLog(sessionId, entry);
 
         const message = JSON.stringify(entry);
         for (const ws of session.sockets) {

--- a/apps/debug/session-sockets.test.js
+++ b/apps/debug/session-sockets.test.js
@@ -134,26 +134,27 @@ test('sweeping does not evict or close a session with a live socket connection',
     server.close();
 });
 
-test('connecting replays buffered history oldest-first before any new broadcast', async() => {
+test('connecting does not replay any prior history — only live broadcasts after connecting arrive', async() => {
     const sessionStore = createSessionStore();
-    const { id: sessionId, session } = sessionStore.createSession();
-    // requestLog is maintained newest-first (unshift), as today.
-    session.requestLog = [
-        { id: '2', method: 'POST' },
-        { id: '1', method: 'GET' }
-    ];
-    const { attach } = createSessionSockets({ sessionStore });
+    const { id: sessionId } = sessionStore.createSession();
+    const { attach, broadcast } = createSessionSockets({ sessionStore });
+    // A broadcast before any socket connects has nowhere to go — logs are
+    // never stored server-side, so there's nothing to replay later.
+    broadcast(sessionId, { id: 'before-connect', method: 'GET' });
+
     const server = http.createServer();
     attach(server);
     const port = await listen(server);
 
     const ws = new WebSocket(`ws://127.0.0.1:${port}/s/${sessionId}/logs`);
-    const replayed = [];
-    ws.on('message', data => replayed.push(JSON.parse(data.toString())));
+    const received = [];
+    ws.on('message', data => received.push(JSON.parse(data.toString())));
     await waitForOpen(ws);
-    await waitUntil(() => replayed.length === 2);
 
-    assert.deepEqual(replayed.map(e => e.id), ['1', '2']);
+    broadcast(sessionId, { id: 'after-connect', method: 'POST' });
+    await waitUntil(() => received.length === 1);
+
+    assert.deepEqual(received.map(e => e.id), ['after-connect']);
 
     ws.close();
     server.close();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,7 +80,8 @@ module.exports = [
                 navigator: 'readonly',
                 location: 'readonly',
                 localStorage: 'readonly',
-                sessionStorage: 'readonly'
+                sessionStorage: 'readonly',
+                URL: 'readonly'
             }
         }
     }


### PR DESCRIPTION
…ation

Replaces the old per-action protocol/server-override fields with a persistent, per-session Settings page (feed URL, rssCloud protocol and endpoints, WebSub hub/lease/secret), reachable via a gear icon. Entering an external feed URL triggers discovery — the traditional <cloud> element, the newer <source:cloud> (per source.scripting.com, correctly a plain URL with no attributes), and a WebSub hub via the HTTP Link header or a feed-embedded link — to prefill the rest of the form, with a Reset control to fall back to this session's own feed.

The main page collapses to three settings-driven action rows (Feed / rssCloud / WebSub), each shown only when enabled. The self-served test feed now reflects the session's own settings (not the global default), emits <cloud>/<source:cloud>/<atom:link> before <item>, and advertises its hub via both the feed body and an HTTP Link header.

Other behavior changes bundled with this feature:
- The traffic log is now purely live (no server-side storage) — any reload starts empty.
- "Update Feed" is now the only action that bumps feed content; Ping and Publish just notify about whatever's already there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-session Settings page with saved defaults for feed, rssCloud, and WebSub, including previewing derived settings from a feed URL.
  * Improved feed discovery and auto-fill for external feeds, including better hub/self link handling.
  * Added a live traffic log that shows only new activity during the current session (no backfilled history).

* **Bug Fixes**
  * Updated served feed metadata and action behavior to reflect the currently saved session settings (rssCloud/WebSub on/off, hub/link headers).
  * Improved validation and sensitive WebSub handling, with clearer error behavior and redacted log output.

* **Documentation**
  * Refreshed debug harness README and example configuration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->