### PR TITLE
fix(debug): settings page UI fixes + WebSub hub.verify compatibility

### DIFF
--- a/apps/debug/debug.js
+++ b/apps/debug/debug.js
@@ -147,6 +147,15 @@ const debugStyles = `
             flex: 1;
             min-width: 220px;
         }
+        /* style.css's label { display: block } stretches these checkbox
+           labels across the whole fieldset, so clicking far past the
+           "Disabled" text still toggles the checkbox. Shrink to content. */
+        .checkbox-label {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            width: auto;
+        }
         .input-with-button {
             display: flex;
             gap: 10px;
@@ -307,7 +316,7 @@ function renderSettingsPage(sessionId, settings, { error } = {}) {
 
         <fieldset id="rsscloudFields">
             <legend>rssCloud</legend>
-            <label>
+            <label class="checkbox-label">
                 <input type="checkbox" id="rssCloudDisabled" name="rssCloudDisabled" ${settings.rssCloud.disabled ? 'checked' : ''}>
                 Disabled
             </label>
@@ -348,7 +357,7 @@ function renderSettingsPage(sessionId, settings, { error } = {}) {
 
         <fieldset id="webSubFields">
             <legend>WebSub</legend>
-            <label>
+            <label class="checkbox-label">
                 <input type="checkbox" id="webSubDisabled" name="webSubDisabled" ${settings.webSub.disabled ? 'checked' : ''}>
                 Disabled
             </label>

--- a/apps/debug/lib/websub.js
+++ b/apps/debug/lib/websub.js
@@ -19,11 +19,16 @@ function createWebSubClient(options) {
     }
 
     // The callback+topic form both subscribe and unsubscribe open with.
+    // `hub.verify` is a legacy PubSubHubbub field the current WebSub spec
+    // dropped (verification is always async now), but some hubs still
+    // reject a request that omits it — we always verify async, so it's
+    // safe to send unconditionally.
     function callbackForm(mode, opts) {
         return new URLSearchParams({
             'hub.mode': mode,
             'hub.callback': opts.callbackUrl,
-            'hub.topic': opts.topicUrl
+            'hub.topic': opts.topicUrl,
+            'hub.verify': 'async'
         });
     }
 

--- a/apps/debug/lib/websub.test.js
+++ b/apps/debug/lib/websub.test.js
@@ -40,6 +40,7 @@ test('subscribe posts the hub.* subscribe form to /websub', async() => {
         'http://sub.example:9000/websub-callback'
     );
     assert.equal(body.get('hub.topic'), 'https://feed.example/rss');
+    assert.equal(body.get('hub.verify'), 'async');
     assert.deepEqual(res, { status: 202, body: '' });
 });
 
@@ -115,6 +116,7 @@ test('unsubscribe posts hub.mode=unsubscribe with callback and topic', async() =
         'http://sub.example:9000/websub-callback'
     );
     assert.equal(body.get('hub.topic'), 'https://feed.example/rss');
+    assert.equal(body.get('hub.verify'), 'async');
 });
 
 test('targets a configurable hub path', async() => {

--- a/apps/debug/public/css/style.css
+++ b/apps/debug/public/css/style.css
@@ -65,7 +65,8 @@ label {
     font-weight: bold;
 }
 
-input[type='text'] {
+input[type='text'],
+input[type='password'] {
     width: 100%;
     padding: 10px;
     border: 1px solid #ddd;


### PR DESCRIPTION
## Summary
- Style the secret input on the debug settings page like other fields (`input[type='password']` was unstyled).
- Shrink the rssCloud/WebSub "Disabled" checkbox labels to their content so clicking whitespace far past the label text no longer toggles the checkbox.
- Send `hub.verify=async` on WebSub subscribe/unsubscribe so hubs still implementing the legacy PubSubHubbub spec (which require the field) don't reject the request with `400 hub.verify is empty`.

## Test plan
- [x] `node --test lib/*.test.js *.test.js` in `apps/debug` (174 passing)
- [ ] Verify in production: settings page secret field renders full-width, checkbox click area matches visible label, WebSub subscribe against a real external hub succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved debug page form styling so checkbox labels no longer stretch awkwardly, making the layout cleaner and easier to use.
  * Password fields now match text fields in appearance for more consistent form styling.

* **Bug Fixes**
  * Updated WebSub request handling so subscription and unsubscription flows send the expected verification setting, improving compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->