### PR TITLE
fix(debug): advertise a correct externally-reachable PUBLIC_URL

### DIFF
--- a/apps/debug/.env.example
+++ b/apps/debug/.env.example
@@ -15,6 +15,15 @@
 DOMAIN=localhost
 PORT=9000
 
+# The externally-reachable base URL this harness advertises for its own
+# WebSub callback, rssCloud callback, and self-hosted feed links — defaults
+# to http://${DOMAIN}:${PORT}, which is right for a direct, non-proxied setup
+# like local dev. Set this explicitly when deployed behind a reverse proxy
+# that terminates TLS or maps a different public port than PORT above (e.g.
+# 443 -> an internal 3013) — otherwise the internal PORT leaks into URLs sent
+# to real hubs/subscribers, who can't reach it.
+# PUBLIC_URL=https://debug.example.com
+
 # --- Default hub / WebSub target --------------------------------------------
 # Seeds each new session's default settings (rssCloud ping/subscribe/RPC2
 # URLs, WebSub hub URL) computed on first visit — from the session's

--- a/apps/debug/config.js
+++ b/apps/debug/config.js
@@ -1,3 +1,4 @@
+const { URL } = require('url');
 const packageJson = require('./package.json');
 
 // Simple config utility that reads from process.env with defaults
@@ -29,6 +30,24 @@ function getCidrListConfig(key) {
         .filter(Boolean);
 }
 
+// Validate a URL env var at startup, same fail-fast rule as
+// getNumericConfig: only the unset case falls back to defaultValue — a
+// present-but-malformed value throws here instead of surfacing later as an
+// uncaught `new URL()` throw mid-request (selfHostedPrefixes, the
+// rsscloud-subscribe route).
+function getUrlConfig(key, defaultValue) {
+    const value = process.env[key];
+    if (value === undefined) {
+        return defaultValue;
+    }
+    try {
+        new URL(value);
+    } catch {
+        throw new Error(`Invalid URL value for ${key}: "${value}"`);
+    }
+    return value;
+}
+
 const domain = getConfig('DOMAIN', 'localhost');
 const port = getNumericConfig('PORT', 9000);
 
@@ -43,7 +62,7 @@ module.exports = {
     // proxy in front of a public deployment typically terminates TLS on a
     // different port than the one this process actually binds. Defaults to
     // DOMAIN/PORT for a direct, non-proxied local dev setup.
-    publicUrl: getConfig('PUBLIC_URL', `http://${domain}:${port}`).replace(/\/$/, ''),
+    publicUrl: getUrlConfig('PUBLIC_URL', `http://${domain}:${port}`).replace(/\/$/, ''),
     hubServerUrl: getConfig('HUB_SERVER_URL', 'http://localhost:5337'),
     requestTimeout: getNumericConfig('REQUEST_TIMEOUT', 4000),
     debugFetchAllowCidrs: getCidrListConfig('DEBUG_FETCH_ALLOW_CIDRS'),

--- a/apps/debug/config.js
+++ b/apps/debug/config.js
@@ -29,11 +29,21 @@ function getCidrListConfig(key) {
         .filter(Boolean);
 }
 
+const domain = getConfig('DOMAIN', 'localhost');
+const port = getNumericConfig('PORT', 9000);
+
 module.exports = {
     appName: 'rssCloudDebug',
     appVersion: packageJson.version,
-    domain: getConfig('DOMAIN', 'localhost'),
-    port: getNumericConfig('PORT', 9000),
+    domain,
+    port,
+    // The externally-reachable base URL this harness advertises for its own
+    // WebSub callback, rssCloud callback, and self-hosted feed links — distinct
+    // from DOMAIN/PORT above (the internal listen address), since a reverse
+    // proxy in front of a public deployment typically terminates TLS on a
+    // different port than the one this process actually binds. Defaults to
+    // DOMAIN/PORT for a direct, non-proxied local dev setup.
+    publicUrl: getConfig('PUBLIC_URL', `http://${domain}:${port}`).replace(/\/$/, ''),
     hubServerUrl: getConfig('HUB_SERVER_URL', 'http://localhost:5337'),
     requestTimeout: getNumericConfig('REQUEST_TIMEOUT', 4000),
     debugFetchAllowCidrs: getCidrListConfig('DEBUG_FETCH_ALLOW_CIDRS'),

--- a/apps/debug/config.publicUrl.invalid.test.js
+++ b/apps/debug/config.publicUrl.invalid.test.js
@@ -1,0 +1,13 @@
+// Isolated in its own file/process: config.js computes its exports at
+// require-time from process.env, so exercising a malformed PUBLIC_URL means
+// setting it before the very first require of this module.
+process.env.PUBLIC_URL = 'not-a-url';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('config.js fails loudly when PUBLIC_URL is present but not a valid URL', () => {
+    assert.throws(() => {
+        require('./config');
+    }, /Invalid URL value for PUBLIC_URL/);
+});

--- a/apps/debug/config.publicUrl.test.js
+++ b/apps/debug/config.publicUrl.test.js
@@ -1,0 +1,21 @@
+// Isolated in its own file/process: config.js computes its exports at
+// require-time from process.env, so exercising a specific PUBLIC_URL means
+// setting it before the very first require of this module.
+process.env.PUBLIC_URL = 'https://debug.rsscloud.io';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const config = require('./config');
+
+test('config.js uses PUBLIC_URL as the externally-advertised base URL when set', () => {
+    assert.equal(config.publicUrl, 'https://debug.rsscloud.io');
+});
+
+test('config.js strips a trailing slash from PUBLIC_URL', () => {
+    // Same process/require cache as above — publicUrl is already computed, so
+    // this just re-asserts the already-normalized value has no trailing slash
+    // rather than re-requiring with a different env var (see the sibling
+    // no-PUBLIC_URL default test in its own file for that case).
+    assert.ok(!config.publicUrl.endsWith('/'));
+});
+

--- a/apps/debug/debug.js
+++ b/apps/debug/debug.js
@@ -33,6 +33,16 @@ const bodyParser = require('body-parser'),
 // Derive a self-served test feed's <cloud> element from a session's own
 // rssCloud settings — undefined (omitted entirely) when rssCloud is
 // disabled. The RPC2 endpoint doubles as both ping and subscribe front door.
+// Split a parsed URL into rssCloud's wire {domain, port} shape — hostname,
+// and an explicit port or the scheme's conventional one (80/443) when
+// omitted (a bare hostname URL still needs a real port on the wire).
+function hostPortFromUrl(target) {
+    return {
+        domain: target.hostname,
+        port: Number(target.port) || (target.protocol === 'https:' ? 443 : 80)
+    };
+}
+
 function cloudFromSettings(rssCloud) {
     if (rssCloud.disabled) {
         return undefined;
@@ -40,8 +50,7 @@ function cloudFromSettings(rssCloud) {
     const useXmlRpc = rssCloud.protocol === 'xml-rpc';
     const target = new URL(useXmlRpc ? rssCloud.rpcUrl : rssCloud.subscribeUrl);
     return {
-        domain: target.hostname,
-        port: Number(target.port) || (target.protocol === 'https:' ? 443 : 80),
+        ...hostPortFromUrl(target),
         path: target.pathname,
         registerProcedure: useXmlRpc ? 'rssCloud.pleaseNotify' : '',
         protocol: rssCloud.protocol
@@ -66,7 +75,7 @@ function isValidHttpUrl(value) {
 // This session's callback URL the hub notifies for WebSub content
 // distribution and intent verification.
 function webSubCallbackUrl(sessionId) {
-    return `http://${config.domain}:${config.port}/s/${sessionId}/websub-callback`;
+    return `${config.publicUrl}/s/${sessionId}/websub-callback`;
 }
 
 // Pull the topic URL out of a delivery's Link header (`<url>; rel="self"`).
@@ -291,7 +300,7 @@ function renderPage(sessionId, wsUrl, settings, { isSelfHosted, showPing, lastUp
 // Protocol-dependent field visibility is toggled client-side (public/settings.js)
 // since it must react live to the form's own dropdown/checkbox changes.
 function renderSettingsPage(sessionId, settings, { error } = {}) {
-    const ctx = { domain: config.domain, port: config.port, sessionId };
+    const ctx = { publicUrl: config.publicUrl, sessionId };
     const context = {
         selfHostedPrefixes: selfHostedPrefixes(ctx),
         defaultSettings: computeDefaultSettings({ ...ctx, hubServerUrl: config.hubServerUrl })
@@ -541,7 +550,7 @@ function createApp({
         const wsProtocol = req.protocol === 'https' ? 'wss' : 'ws';
         const wsUrl = `${wsProtocol}://${req.get('host')}/s/${sessionId}/logs`;
         const { settings } = req.session;
-        const ctx = { domain: config.domain, port: config.port, sessionId };
+        const ctx = { publicUrl: config.publicUrl, sessionId };
         const isSelfHosted = isSelfHostedFeedUrl(settings.feedUrl, ctx);
         const showPing = settings.rssCloud.protocol === 'xml-rpc' || Boolean(settings.rssCloud.pingUrl);
         const lastUpdatedAt = isSelfHosted
@@ -627,18 +636,44 @@ function createApp({
         }
     });
 
-    // Shared by every settings-driven action below: broadcasts the
-    // request/response pair around `call()`, and never mutates session state
-    // (via `onSuccess`) on the strength of a request that might still fail.
-    function logAndRespondAction(sessionId, res, action, targetUrl, requestBody, call, onSuccess) {
-        const logId = crypto.randomUUID();
-        broadcastOutgoingRequest(sessionId, {
-            id: logId,
-            timestamp: new Date().toISOString(),
-            method: 'POST',
-            url: targetUrl,
-            body: { action, ...requestBody }
-        });
+    // A urlencoded wire body is logged as a plain object (matching how the
+    // incoming-request logging middleware already logs req.body); an XML-RPC
+    // body is already human-readable, so it's logged as-is.
+    function parseLoggedBody(headers, body) {
+        if (headers['Content-Type'] === 'application/x-www-form-urlencoded') {
+            return Object.fromEntries(new URLSearchParams(body));
+        }
+        return body;
+    }
+
+    // The client's onRequest hook fires with the real request (method/url/
+    // headers/body) synchronously, before the fetch is dispatched — logging
+    // that directly means the traffic log can never drift from what's
+    // actually sent. `redact` optionally scrubs sensitive fields from the
+    // logged copy only (the real request, already captured by the client,
+    // is unaffected).
+    function onOutgoingRequest(sessionId, logId, redact) {
+        return request => {
+            const body = parseLoggedBody(request.headers, request.body);
+            if (redact && body && typeof body === 'object') {
+                redact(body);
+            }
+            broadcastOutgoingRequest(sessionId, {
+                id: logId,
+                timestamp: new Date().toISOString(),
+                method: request.method,
+                url: request.url,
+                body
+            });
+        };
+    }
+
+    // Shared by every settings-driven action below: broadcasts the response
+    // half of the request/response pair around `call()` (the request half is
+    // already broadcast by the client's onRequest hook — see above), and
+    // never mutates session state (via `onSuccess`) on the strength of a
+    // request that might still fail.
+    function logAndRespondAction(sessionId, res, logId, call, onSuccess) {
         return call()
             .then(result => {
                 onSuccess?.(result);
@@ -682,14 +717,17 @@ function createApp({
 
         const useXmlRpc = protocol === 'xml-rpc';
         const targetUrl = useXmlRpc ? rpcUrl : subscribeUrl;
-        const rssCloudClient = createRssCloudClient({ fetch });
+        const logId = crypto.randomUUID();
+        const rssCloudClient = createRssCloudClient({
+            fetch,
+            onRequest: onOutgoingRequest(sessionId, logId)
+        });
         const subscribeParams = {
             url: targetUrl,
             protocol,
             accept: useXmlRpc ? undefined : accepts,
             callback: {
-                domain: config.domain,
-                port: config.port,
+                ...hostPortFromUrl(new URL(config.publicUrl)),
                 path: useXmlRpc
                     ? `/s/${sessionId}/RPC2`
                     : `/s/${sessionId}/notify`
@@ -700,9 +738,7 @@ function createApp({
         logAndRespondAction(
             sessionId,
             res,
-            'rsscloud-subscribe',
-            targetUrl,
-            subscribeParams,
+            logId,
             () => rssCloudClient.pleaseNotify(subscribeParams)
         );
     });
@@ -727,7 +763,11 @@ function createApp({
         }
 
         const targetUrl = useXmlRpc ? rpcUrl : pingUrl;
-        const rssCloudClient = createRssCloudClient({ fetch });
+        const logId = crypto.randomUUID();
+        const rssCloudClient = createRssCloudClient({
+            fetch,
+            onRequest: onOutgoingRequest(sessionId, logId)
+        });
         const pingParams = {
             url: targetUrl,
             feedUrl: settings.feedUrl,
@@ -738,9 +778,7 @@ function createApp({
         logAndRespondAction(
             sessionId,
             res,
-            'rsscloud-ping',
-            targetUrl,
-            pingParams,
+            logId,
             () => rssCloudClient.ping(pingParams)
         );
     });
@@ -757,16 +795,25 @@ function createApp({
         }
 
         const { hubUrl: targetUrl, leaseSeconds, secret } = settings.webSub;
-        const hub = createWebSubClient({ serverUrl: targetUrl, path: '', fetch });
+        const logId = crypto.randomUUID();
+        const hub = createWebSubClient({
+            serverUrl: targetUrl,
+            path: '',
+            fetch,
+            // Redact the secret in the logged/broadcast copy only — it's
+            // still sent verbatim to the hub below, just never echoed into
+            // the log.
+            onRequest: onOutgoingRequest(sessionId, logId, body => {
+                if (body['hub.secret']) {
+                    body['hub.secret'] = '(redacted)';
+                }
+            })
+        });
 
         logAndRespondAction(
             sessionId,
             res,
-            'websub-subscribe',
-            targetUrl,
-            // Redact the secret in the logged/broadcast copy — it's still
-            // sent verbatim to the hub below, just never echoed into the log.
-            { topicUrl: feedUrl, leaseSeconds, secret: secret ? '(redacted)' : undefined },
+            logId,
             () => hub.subscribe({
                 callbackUrl: webSubCallbackUrl(sessionId),
                 topicUrl: feedUrl,
@@ -795,14 +842,18 @@ function createApp({
         }
 
         const targetUrl = settings.webSub.hubUrl;
-        const hub = createWebSubClient({ serverUrl: targetUrl, path: '', fetch });
+        const logId = crypto.randomUUID();
+        const hub = createWebSubClient({
+            serverUrl: targetUrl,
+            path: '',
+            fetch,
+            onRequest: onOutgoingRequest(sessionId, logId)
+        });
 
         logAndRespondAction(
             sessionId,
             res,
-            'websub-unsubscribe',
-            targetUrl,
-            { topicUrl: feedUrl },
+            logId,
             () => hub.unsubscribe({
                 callbackUrl: webSubCallbackUrl(sessionId),
                 topicUrl: feedUrl
@@ -827,14 +878,18 @@ function createApp({
         }
 
         const targetUrl = settings.webSub.hubUrl;
-        const hub = createWebSubClient({ serverUrl: targetUrl, path: '', fetch });
+        const logId = crypto.randomUUID();
+        const hub = createWebSubClient({
+            serverUrl: targetUrl,
+            path: '',
+            fetch,
+            onRequest: onOutgoingRequest(sessionId, logId)
+        });
 
         logAndRespondAction(
             sessionId,
             res,
-            'websub-publish',
-            targetUrl,
-            { topicUrl: feedUrl },
+            logId,
             () => hub.publish({ topicUrl: feedUrl })
         );
     });
@@ -845,7 +900,7 @@ function createApp({
     sessionRouter.post('/actions/update-feed', ensureSession, (req, res) => {
         const sessionId = req.params.sessionId;
         const { settings } = req.session;
-        const ctx = { domain: config.domain, port: config.port, sessionId };
+        const ctx = { publicUrl: config.publicUrl, sessionId };
 
         if (!isSelfHostedFeedUrl(settings.feedUrl, ctx)) {
             res.json({ error: 'feed is not self-hosted' });
@@ -922,7 +977,7 @@ function createApp({
         const items = req.session.feedItems[feedName] || [
             { title: 'initialized', timestamp: new Date() }
         ];
-        const feedUrl = `http://${config.domain}:${config.port}/s/${sessionId}/${feedName}`;
+        const feedUrl = `${config.publicUrl}/s/${sessionId}/${feedName}`;
         const hub = settings.webSub.disabled ? undefined : settings.webSub.hubUrl;
 
         const rssXml = renderCloudFeed({

--- a/apps/debug/debug.public-url.test.js
+++ b/apps/debug/debug.public-url.test.js
@@ -1,0 +1,68 @@
+// Isolated from debug.test.js: PUBLIC_URL must be set before config.js
+// (required transitively by debug.js) reads process.env, and config.js is a
+// module-level singleton — this can only be exercised in its own process,
+// which `node --test` already gives each file.
+process.env.PUBLIC_URL = 'https://debug.rsscloud.io';
+process.env.DOMAIN = 'debug.rsscloud.io';
+process.env.PORT = '3013';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createApp } = require('./debug');
+const request = require('supertest');
+
+test('websub-subscribe sends hub.callback built from PUBLIC_URL, not the internal listen DOMAIN/PORT', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 202, text: async() => '' };
+    };
+    const app = createApp({ fetch });
+    const sessionId = 'public-url-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    await request(app)
+        .post(`/s/${sessionId}/actions/websub-subscribe`)
+        .send({});
+
+    const body = new URLSearchParams(calls[0].init.body);
+    assert.equal(
+        body.get('hub.callback'),
+        `https://debug.rsscloud.io/s/${sessionId}/websub-callback`
+    );
+});
+
+test('rsscloud-subscribe sends a callback domain/port derived from PUBLIC_URL, not the internal listen PORT', async() => {
+    const calls = [];
+    const fetch = async(url, init) => {
+        calls.push({ url: String(url), init });
+        return { status: 200, text: async() => 'ok' };
+    };
+    const app = createApp({ fetch });
+    const sessionId = 'public-url-rsscloud-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    await request(app)
+        .post(`/s/${sessionId}/actions/rsscloud-subscribe`)
+        .send({});
+
+    const body = new URLSearchParams(calls[0].init.body);
+    assert.equal(body.get('domain'), 'debug.rsscloud.io');
+    // PUBLIC_URL carries no explicit port, and its scheme is https, so the
+    // externally-reachable port is 443 — not the internal PORT=3013 this
+    // process actually binds to.
+    assert.equal(body.get('port'), '443');
+});
+
+test('the self-hosted feed\'s <link> is built from PUBLIC_URL, not the internal listen DOMAIN/PORT', async() => {
+    const app = createApp();
+    const sessionId = 'public-url-feed-link-session';
+
+    await request(app).get(`/s/${sessionId}`);
+    const res = await request(app).get(`/s/${sessionId}/rss.xml`);
+
+    assert.match(
+        res.text,
+        new RegExp(`<link>https://debug\\.rsscloud\\.io/s/${sessionId}/rss\\.xml</link>`)
+    );
+});

--- a/apps/debug/debug.test.js
+++ b/apps/debug/debug.test.js
@@ -681,6 +681,29 @@ test('subscribing logs an outgoing request entry and a paired response entry', a
     await harness.close();
 });
 
+test('subscribing logs the real outgoing wire body, not the internal action params', async() => {
+    const sessionStore = createSessionStore();
+    const app = createApp({ fetch: fakeFetch(200, 'thanks'), sessionStore });
+    const sessionId = 'log-wire-session';
+    const harness = await startTestServer(app);
+    await harness.request.get(`/s/${sessionId}`);
+    const { ws, received } = await harness.openLogSocket(sessionId);
+
+    await harness.request.post(`/s/${sessionId}/actions/rsscloud-subscribe`).send({});
+    await waitUntil(() => received.length === 2);
+
+    const [requestEntry] = received;
+    // The real rssCloud pleaseNotify wire form — port/path/protocol/url1 —
+    // not the internal { action, callback: {...}, feedUrl } shape.
+    assert.equal(requestEntry.body.protocol, 'http-post');
+    assert.equal(requestEntry.body.url1, sessionStore.get(sessionId).settings.feedUrl);
+    assert.equal(requestEntry.body.path, `/s/${sessionId}/notify`);
+    assert.equal(requestEntry.body.action, undefined);
+
+    ws.close();
+    await harness.close();
+});
+
 test('pinging logs an outgoing request entry and a paired response entry', async() => {
     const sessionStore = createSessionStore();
     const app = createApp({ fetch: fakeFetch(200, 'ok'), sessionStore });
@@ -743,7 +766,10 @@ test('websub-subscribe redacts the secret in the logged request, but sends it ve
     const requestEntry = received.find(
         e => e.direction === 'outgoing' && e.phase === 'request'
     );
-    assert.notEqual(requestEntry.body.secret, 's3cr3t');
+    assert.equal(requestEntry.body['hub.secret'], '(redacted)');
+    // Every other real hub.* field is still visible in the log — only the
+    // secret is redacted.
+    assert.equal(requestEntry.body['hub.mode'], 'subscribe');
 
     const body = new URLSearchParams(calls[0].init.body);
     assert.equal(body.get('hub.secret'), 's3cr3t');

--- a/apps/debug/index.js
+++ b/apps/debug/index.js
@@ -11,9 +11,7 @@ const app = createApp({ sessionStore });
 
 const server = app
     .listen(config.port, () => {
-        console.log(
-            `Listening at http://${config.domain}:${server.address().port}`
-        );
+        console.log(`Listening on port ${server.address().port} — public URL: ${config.publicUrl}`);
     })
     .on('error', error => {
         switch (error.code) {

--- a/apps/debug/lib/client.js
+++ b/apps/debug/lib/client.js
@@ -52,13 +52,25 @@ function acceptHeader(accept) {
 // passes one.
 function createRssCloudClient(options) {
     const doFetch = options.fetch ?? fetch;
+    const onRequest = options.onRequest;
     const base = options.serverUrl ? options.serverUrl.replace(/\/$/, '') : undefined;
 
+    // Reports the exact request about to go out (method/url/headers/body) to
+    // onRequest, synchronously and before the fetch resolves — so a caller
+    // logging outgoing traffic observes the real bytes sent, never a
+    // separately-reconstructed approximation that could drift from it.
     async function send(url, contentType, body, extraHeaders) {
-        const res = await doFetch(url, {
+        const request = {
             method: 'POST',
+            url,
             headers: { 'Content-Type': contentType, ...extraHeaders },
             body
+        };
+        onRequest?.(request);
+        const res = await doFetch(request.url, {
+            method: request.method,
+            headers: request.headers,
+            body: request.body
         });
         return { status: res.status, body: await res.text() };
     }

--- a/apps/debug/lib/client.test.js
+++ b/apps/debug/lib/client.test.js
@@ -253,6 +253,51 @@ test('pleaseNotify over xml-rpc sends an empty domain when none is given', async
     assert.equal(call.params[5], '');
 });
 
+test('pleaseNotify reports the exact outgoing request via onRequest before the fetch resolves', async() => {
+    const { fn, calls } = fakeFetch();
+    const seen = [];
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn,
+        onRequest: request => seen.push(request)
+    });
+
+    await client.pleaseNotify({
+        protocol: 'http-post',
+        callback: { domain: 'sub.example', port: 9000, path: '/notify' },
+        feedUrl: 'https://feed.example/rss'
+    });
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].method, 'POST');
+    assert.equal(seen[0].url, 'http://hub.example:5337/pleaseNotify');
+    assert.equal(
+        seen[0].headers['Content-Type'],
+        'application/x-www-form-urlencoded'
+    );
+    // Same string the fetch call actually sent, not a reconstruction.
+    assert.equal(seen[0].body, calls[0].init.body);
+});
+
+test('pleaseNotify over xml-rpc reports the XML body via onRequest', async() => {
+    const { fn, calls } = fakeFetch();
+    const seen = [];
+    const client = createRssCloudClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn,
+        onRequest: request => seen.push(request)
+    });
+
+    await client.pleaseNotify({
+        protocol: 'xml-rpc',
+        callback: { domain: 'sub.example', port: 9000, path: '/RPC2' },
+        feedUrl: 'https://feed.example/rss'
+    });
+
+    assert.equal(seen[0].headers['Content-Type'], 'text/xml');
+    assert.equal(seen[0].body, calls[0].init.body);
+});
+
 test('strips a trailing slash from the server URL', async() => {
     const { fn, calls } = fakeFetch();
     const client = createRssCloudClient({

--- a/apps/debug/lib/session-store.js
+++ b/apps/debug/lib/session-store.js
@@ -17,8 +17,7 @@ function createSessionStore({
     idGenerator = randomUUID,
     buildDefaultSettings = id => computeDefaultSettings({
         sessionId: id,
-        domain: config.domain,
-        port: config.port,
+        publicUrl: config.publicUrl,
         hubServerUrl: config.hubServerUrl
     })
 } = {}) {

--- a/apps/debug/lib/settings.js
+++ b/apps/debug/lib/settings.js
@@ -1,9 +1,11 @@
+const { URL } = require('url');
+
 const SELF_HOSTED_FEED_NAME = 'rss.xml';
 
-function computeDefaultSettings({ sessionId, domain, port, hubServerUrl }) {
+function computeDefaultSettings({ sessionId, publicUrl, hubServerUrl }) {
     const hub = hubServerUrl.replace(/\/$/, '');
     return {
-        feedUrl: `http://${domain}:${port}/s/${sessionId}/${SELF_HOSTED_FEED_NAME}`,
+        feedUrl: `${publicUrl}/s/${sessionId}/${SELF_HOSTED_FEED_NAME}`,
         rssCloud: {
             disabled: false,
             protocol: 'http-post',
@@ -21,10 +23,15 @@ function computeDefaultSettings({ sessionId, domain, port, hubServerUrl }) {
     };
 }
 
-function selfHostedPrefixes({ domain, port, sessionId }) {
+// Match either scheme against publicUrl's own host — a feed URL typed or
+// discovered with the other scheme against the same host:port should still
+// be recognized as self-hosted.
+function selfHostedPrefixes({ publicUrl, sessionId }) {
+    const url = new URL(publicUrl);
+    const otherScheme = url.protocol === 'https:' ? 'http' : 'https';
     return [
-        `http://${domain}:${port}/s/${sessionId}/`,
-        `https://${domain}:${port}/s/${sessionId}/`
+        `${url.protocol}//${url.host}/s/${sessionId}/`,
+        `${otherScheme}://${url.host}/s/${sessionId}/`
     ];
 }
 

--- a/apps/debug/lib/settings.test.js
+++ b/apps/debug/lib/settings.test.js
@@ -8,22 +8,30 @@ const {
     applyDiscoveryToSettings
 } = require('./settings');
 
-test('computeDefaultSettings builds the self-hosted feed URL from domain/port/session', () => {
+test('computeDefaultSettings builds the self-hosted feed URL from publicUrl/session', () => {
     const settings = computeDefaultSettings({
         sessionId: 'abc-123',
-        domain: 'localhost',
-        port: 9000,
+        publicUrl: 'http://localhost:9000',
         hubServerUrl: 'http://localhost:5337'
     });
 
     assert.equal(settings.feedUrl, 'http://localhost:9000/s/abc-123/rss.xml');
 });
 
+test('computeDefaultSettings builds the self-hosted feed URL using publicUrl\'s own scheme, not a hardcoded http', () => {
+    const settings = computeDefaultSettings({
+        sessionId: 'abc-123',
+        publicUrl: 'https://debug.rsscloud.io',
+        hubServerUrl: 'http://localhost:5337'
+    });
+
+    assert.equal(settings.feedUrl, 'https://debug.rsscloud.io/s/abc-123/rss.xml');
+});
+
 test('computeDefaultSettings defaults rssCloud to http-post against the configured hub', () => {
     const settings = computeDefaultSettings({
         sessionId: 'abc-123',
-        domain: 'localhost',
-        port: 9000,
+        publicUrl: 'http://localhost:9000',
         hubServerUrl: 'http://localhost:5337'
     });
 
@@ -40,8 +48,7 @@ test('computeDefaultSettings defaults rssCloud to http-post against the configur
 test('computeDefaultSettings defaults webSub to enabled with a blank lease/secret', () => {
     const settings = computeDefaultSettings({
         sessionId: 'abc-123',
-        domain: 'localhost',
-        port: 9000,
+        publicUrl: 'http://localhost:9000',
         hubServerUrl: 'http://localhost:5337'
     });
 
@@ -56,18 +63,16 @@ test('computeDefaultSettings defaults webSub to enabled with a blank lease/secre
 test('computeDefaultSettings strips a trailing slash from the hub server URL', () => {
     const settings = computeDefaultSettings({
         sessionId: 'abc-123',
-        domain: 'localhost',
-        port: 9000,
+        publicUrl: 'http://localhost:9000',
         hubServerUrl: 'http://localhost:5337/'
     });
 
     assert.equal(settings.rssCloud.pingUrl, 'http://localhost:5337/ping');
 });
 
-test('selfHostedPrefixes lists the http and https prefixes for this session', () => {
+test('selfHostedPrefixes lists both scheme prefixes for this session, using publicUrl\'s host', () => {
     const prefixes = selfHostedPrefixes({
-        domain: 'localhost',
-        port: 9000,
+        publicUrl: 'http://localhost:9000',
         sessionId: 'abc-123'
     });
 
@@ -77,7 +82,19 @@ test('selfHostedPrefixes lists the http and https prefixes for this session', ()
     ]);
 });
 
-const ctx = { domain: 'localhost', port: 9000, sessionId: 'abc-123' };
+test('selfHostedPrefixes derives both scheme prefixes from an https publicUrl, still matching an http-typed feed URL', () => {
+    const prefixes = selfHostedPrefixes({
+        publicUrl: 'https://debug.rsscloud.io',
+        sessionId: 'abc-123'
+    });
+
+    assert.deepEqual(prefixes, [
+        'https://debug.rsscloud.io/s/abc-123/',
+        'http://debug.rsscloud.io/s/abc-123/'
+    ]);
+});
+
+const ctx = { publicUrl: 'http://localhost:9000', sessionId: 'abc-123' };
 
 test('feedNameFromSelfHostedUrl extracts the feed name from a self-hosted URL', () => {
     const name = feedNameFromSelfHostedUrl(
@@ -114,8 +131,7 @@ test('isSelfHostedFeedUrl is false for an external feed URL', () => {
 function baseSettings() {
     return computeDefaultSettings({
         sessionId: 'abc-123',
-        domain: 'localhost',
-        port: 9000,
+        publicUrl: 'http://localhost:9000',
         hubServerUrl: 'http://localhost:5337'
     });
 }

--- a/apps/debug/lib/websub.js
+++ b/apps/debug/lib/websub.js
@@ -6,14 +6,26 @@ const FORM_TYPE = 'application/x-www-form-urlencoded';
 // without throwing on a non-2xx — inspect `status` yourself.
 function createWebSubClient(options) {
     const doFetch = options.fetch ?? fetch;
+    const onRequest = options.onRequest;
     const base = options.serverUrl.replace(/\/$/, '');
     const path = options.path ?? '/websub';
 
+    // Reports the exact request about to go out (method/url/headers/body) to
+    // onRequest, synchronously and before the fetch resolves — so a caller
+    // logging outgoing traffic observes the real bytes sent, never a
+    // separately-reconstructed approximation that could drift from it.
     async function send(form) {
-        const res = await doFetch(`${base}${path}`, {
+        const request = {
             method: 'POST',
+            url: `${base}${path}`,
             headers: { 'Content-Type': FORM_TYPE },
             body: form.toString()
+        };
+        onRequest?.(request);
+        const res = await doFetch(request.url, {
+            method: request.method,
+            headers: request.headers,
+            body: request.body
         });
         return { status: res.status, body: await res.text() };
     }

--- a/apps/debug/lib/websub.test.js
+++ b/apps/debug/lib/websub.test.js
@@ -119,6 +119,34 @@ test('unsubscribe posts hub.mode=unsubscribe with callback and topic', async() =
     assert.equal(body.get('hub.verify'), 'async');
 });
 
+test('subscribe reports the exact outgoing request via onRequest before the fetch resolves', async() => {
+    const { fn, calls } = fakeFetch();
+    const seen = [];
+    const client = createWebSubClient({
+        serverUrl: 'http://hub.example:5337',
+        fetch: fn,
+        onRequest: request => seen.push(request)
+    });
+
+    await client.subscribe({
+        callbackUrl: 'http://sub.example:9000/websub-callback',
+        topicUrl: 'https://feed.example/rss',
+        secret: 's3cr3t'
+    });
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].method, 'POST');
+    assert.equal(seen[0].url, 'http://hub.example:5337/websub');
+    assert.equal(
+        seen[0].headers['Content-Type'],
+        'application/x-www-form-urlencoded'
+    );
+    // The reported body is exactly what the fetch call actually sent — same
+    // string, not a reconstruction — so the log can never drift from reality.
+    assert.equal(seen[0].body, calls[0].init.body);
+    assert.match(seen[0].body, /hub\.secret=s3cr3t/);
+});
+
 test('targets a configurable hub path', async() => {
     const { fn, calls } = fakeFetch();
     const client = createWebSubClient({

--- a/examples/dockge/compose.yaml
+++ b/examples/dockge/compose.yaml
@@ -69,6 +69,12 @@ services:
       # own callbacks and test feeds.
       DOMAIN: cloud.example.com
       # PORT: "9000"
+      # If you put a reverse proxy in front of this service instead of
+      # exposing 9000 directly (e.g. terminating TLS on 443), set PUBLIC_URL
+      # to the proxy's public URL — otherwise the internal PORT above leaks
+      # into the WebSub/rssCloud callback URLs this harness sends to real
+      # hubs, which they won't be able to reach:
+      #   PUBLIC_URL: "https://cloud.example.com"
       # Reach the sibling `rsscloud` service by its Compose service name —
       # override at runtime (the UI's server/hub override field) to test a
       # different hub instead.


### PR DESCRIPTION
## Summary
- The debug harness (`apps/debug`) built every callback/feed URL it hands to a hub from its internal `DOMAIN`/`PORT` — wrong when deployed behind a reverse proxy that terminates TLS and maps a different public port (e.g. 443 → 3013). This produced a malformed `hub.callback` that a real WebSub hub rejected in production (`https://debug.rsscloud.io`).
- Add a `PUBLIC_URL` override (mirrors `apps/server`'s existing `HUB_URL` pattern), defaulting to `http://${DOMAIN}:${PORT}` for a direct, non-proxied setup. The WebSub callback, rssCloud callback `domain`/`port`, and the self-hosted feed's `<link>` now all derive from it instead.
- Switch the traffic-log viewer to report the *real* outgoing wire request (via a synchronous `onRequest` hook added to the rssCloud/WebSub clients) instead of an internal action-params object, so the log can't drift from what's actually sent.
- The startup log line now prints `config.publicUrl` instead of reconstructing an address from `DOMAIN`.

## Test plan
- [x] `npm test` in `apps/debug` — 185/185 passing
- [x] `npm run lint` in `apps/debug` — clean
- [ ] Deploy with `PUBLIC_URL=https://debug.rsscloud.io` set and confirm a WebSub subscribe succeeds against a real hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an externally-reachable public base URL for the debug harness, including safer URL construction.
* **Bug Fixes**
  * Updated callbacks, rssCloud/WebSub endpoints, feed links, and self-hosted feed URL discovery to consistently use the public base URL.
  * Improved traffic logging so it reflects the exact outgoing requests and redacts sensitive values appropriately.
* **Documentation**
  * Documented the public URL option and when it’s required behind reverse proxies/TLS terminators.
* **Tests**
  * Added/updated tests for public URL validation, trailing-slash normalization, and outgoing request logging accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->